### PR TITLE
add stm32L4+ discovery kit for BLE access on examples

### DIFF
--- a/examples/Central/LedControl/LedControl.ino
+++ b/examples/Central/LedControl/LedControl.ino
@@ -6,7 +6,7 @@
   it will remotely control the BLE Peripheral's LED, when the button is pressed or released.
 
   The circuit:
-  - STEVAL-MKSBOX1V1, B-L475E-IOT01A1, or a Nucleo board plus the X-NUCLEO-IDB05A1 or the X-NUCLEO-BNRG2A1
+  - STEVAL-MKSBOX1V1, B-L475E-IOT01A1, B_L4S5I_IOT01A, or a Nucleo board plus the X-NUCLEO-IDB05A1 or the X-NUCLEO-BNRG2A1
 
   You can use it with another board that is compatible with this library and the
   Peripherals -> LED example.
@@ -22,8 +22,8 @@ SPIClass SpiHCI(PC3, PD3, PD1);
 HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_1S, PD0, PD4, PA8, 1000000, SPI_MODE1);
 BLELocalDevice BLE(&HCISpiTransport);
 const int buttonPin = PG1; // set buttonPin to digital pin PG1
-#elif defined(ARDUINO_DISCO_L475VG_IOT)
-/* B-L475E-IOT01A1 */
+#elif defined(ARDUINO_DISCO_L475VG_IOT) || defined(ARDUINO_B_L4S5I_IOT01A)
+/* B-L475E-IOT01A1 or B_L4S5I_IOT01A */
 SPIClass SpiHCI(PC12, PC11, PC10);
 HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_RF, PD13, PE6, PA8, 8000000, SPI_MODE0);
 BLELocalDevice BLE(&HCISpiTransport);

--- a/examples/Central/PeripheralExplorer/PeripheralExplorer.ino
+++ b/examples/Central/PeripheralExplorer/PeripheralExplorer.ino
@@ -5,7 +5,7 @@
   is found. Then connects, and discovers + prints all the peripheral's attributes.
 
   The circuit:
-  - STEVAL-MKSBOX1V1, B-L475E-IOT01A1, or a Nucleo board plus the X-NUCLEO-IDB05A1 or the X-NUCLEO-BNRG2A1
+  - STEVAL-MKSBOX1V1, B-L475E-IOT01A1, B_L4S5I_IOT01A, or a Nucleo board plus the X-NUCLEO-IDB05A1 or the X-NUCLEO-BNRG2A1
 
   You can use it with another board that is compatible with this library and the
   Peripherals -> LED example.
@@ -20,8 +20,8 @@
 SPIClass SpiHCI(PC3, PD3, PD1);
 HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_1S, PD0, PD4, PA8, 1000000, SPI_MODE1);
 BLELocalDevice BLE(&HCISpiTransport);
-#elif defined(ARDUINO_DISCO_L475VG_IOT)
-/* B-L475E-IOT01A1 */
+#elif defined(ARDUINO_DISCO_L475VG_IOT) || defined(ARDUINO_B_L4S5I_IOT01A)
+/* B-L475E-IOT01A1 or B_L4S5I_IOT01A */
 SPIClass SpiHCI(PC12, PC11, PC10);
 HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_RF, PD13, PE6, PA8, 8000000, SPI_MODE0);
 BLELocalDevice BLE(&HCISpiTransport);

--- a/examples/Central/Scan/Scan.ino
+++ b/examples/Central/Scan/Scan.ino
@@ -5,7 +5,7 @@
   address, local name, advertised service UUID's.
 
   The circuit:
-  - STEVAL-MKSBOX1V1, B-L475E-IOT01A1, or a Nucleo board plus the X-NUCLEO-IDB05A1 or the X-NUCLEO-BNRG2A1
+  - STEVAL-MKSBOX1V1, B-L475E-IOT01A1, B_L4S5I_IOT01A, or a Nucleo board plus the X-NUCLEO-IDB05A1 or the X-NUCLEO-BNRG2A1
 
   This example code is in the public domain.
 */
@@ -17,8 +17,8 @@
 SPIClass SpiHCI(PC3, PD3, PD1);
 HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_1S, PD0, PD4, PA8, 1000000, SPI_MODE1);
 BLELocalDevice BLE(&HCISpiTransport);
-#elif defined(ARDUINO_DISCO_L475VG_IOT)
-/* B-L475E-IOT01A1 */
+#elif defined(ARDUINO_DISCO_L475VG_IOT) || defined(ARDUINO_B_L4S5I_IOT01A)
+/* B-L475E-IOT01A1 or B_L4S5I_IOT01A */
 SPIClass SpiHCI(PC12, PC11, PC10);
 HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_RF, PD13, PE6, PA8, 8000000, SPI_MODE0);
 BLELocalDevice BLE(&HCISpiTransport);

--- a/examples/Central/ScanCallback/ScanCallback.ino
+++ b/examples/Central/ScanCallback/ScanCallback.ino
@@ -7,7 +7,7 @@
   reported for every single advertisement it makes.
 
   The circuit:
-  - STEVAL-MKSBOX1V1, B-L475E-IOT01A1, or a Nucleo board plus the X-NUCLEO-IDB05A1 or the X-NUCLEO-BNRG2A1
+  - STEVAL-MKSBOX1V1, B-L475E-IOT01A1, B_L4S5I_IOT01A, or a Nucleo board plus the X-NUCLEO-IDB05A1 or the X-NUCLEO-BNRG2A1
 
   This example code is in the public domain.
 */
@@ -19,8 +19,8 @@
 SPIClass SpiHCI(PC3, PD3, PD1);
 HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_1S, PD0, PD4, PA8, 1000000, SPI_MODE1);
 BLELocalDevice BLE(&HCISpiTransport);
-#elif defined(ARDUINO_DISCO_L475VG_IOT)
-/* B-L475E-IOT01A1 */
+#elif defined(ARDUINO_DISCO_L475VG_IOT) || defined(ARDUINO_B_L4S5I_IOT01A)
+/* B-L475E-IOT01A1 or B_L4S5I_IOT01A */
 SPIClass SpiHCI(PC12, PC11, PC10);
 HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_RF, PD13, PE6, PA8, 8000000, SPI_MODE0);
 BLELocalDevice BLE(&HCISpiTransport);

--- a/examples/Central/SensorTagButton/SensorTagButton.ino
+++ b/examples/Central/SensorTagButton/SensorTagButton.ino
@@ -8,7 +8,7 @@
   outputted to the Serial Monitor when one is pressed.
 
   The circuit:
-  - STEVAL-MKSBOX1V1, B-L475E-IOT01A1, or a Nucleo board plus the X-NUCLEO-IDB05A1 or the X-NUCLEO-BNRG2A1
+  - STEVAL-MKSBOX1V1, B-L475E-IOT01A1, B_L4S5I_IOT01A, or a Nucleo board plus the X-NUCLEO-IDB05A1 or the X-NUCLEO-BNRG2A1
   - TI SensorTag
 
   This example code is in the public domain.
@@ -21,8 +21,8 @@
 SPIClass SpiHCI(PC3, PD3, PD1);
 HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_1S, PD0, PD4, PA8, 1000000, SPI_MODE1);
 BLELocalDevice BLE(&HCISpiTransport);
-#elif defined(ARDUINO_DISCO_L475VG_IOT)
-/* B-L475E-IOT01A1 */
+#elif defined(ARDUINO_DISCO_L475VG_IOT) || defined(ARDUINO_B_L4S5I_IOT01A)
+/* B-L475E-IOT01A1 or B_L4S5I_IOT01A */
 SPIClass SpiHCI(PC12, PC11, PC10);
 HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_RF, PD13, PE6, PA8, 8000000, SPI_MODE0);
 BLELocalDevice BLE(&HCISpiTransport);

--- a/examples/Peripheral/ButtonLED/ButtonLED.ino
+++ b/examples/Peripheral/ButtonLED/ButtonLED.ino
@@ -6,7 +6,7 @@
   represents the state of the button.
 
   The circuit:
-  - STEVAL-MKSBOX1V1, B-L475E-IOT01A1, or a Nucleo board plus the X-NUCLEO-IDB05A1 or the X-NUCLEO-BNRG2A1
+  - STEVAL-MKSBOX1V1, B-L475E-IOT01A1, B_L4S5I_IOT01A, or a Nucleo board plus the X-NUCLEO-IDB05A1 or the X-NUCLEO-BNRG2A1
 
   You can use a generic BLE central app, like LightBlue (iOS and Android) or
   nRF Connect (Android), to interact with the services and characteristics
@@ -23,8 +23,8 @@ SPIClass SpiHCI(PC3, PD3, PD1);
 HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_1S, PD0, PD4, PA8, 1000000, SPI_MODE1);
 BLELocalDevice BLE(&HCISpiTransport);
 const int buttonPin = PG1; // set buttonPin to digital pin PG1
-#elif defined(ARDUINO_DISCO_L475VG_IOT)
-/* B-L475E-IOT01A1 */
+#elif defined(ARDUINO_DISCO_L475VG_IOT) || defined(ARDUINO_B_L4S5I_IOT01A)
+/* B-L475E-IOT01A1 or B_L4S5I_IOT01A */
 SPIClass SpiHCI(PC12, PC11, PC10);
 HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_RF, PD13, PE6, PA8, 8000000, SPI_MODE0);
 BLELocalDevice BLE(&HCISpiTransport);

--- a/examples/Peripheral/CallbackLED/CallbackLED.ino
+++ b/examples/Peripheral/CallbackLED/CallbackLED.ino
@@ -6,7 +6,7 @@
   library are used.
 
   The circuit:
-  - STEVAL-MKSBOX1V1, B-L475E-IOT01A1, or a Nucleo board plus the X-NUCLEO-IDB05A1 or the X-NUCLEO-BNRG2A1
+  - STEVAL-MKSBOX1V1, B-L475E-IOT01A1, B_L4S5I_IOT01A, or a Nucleo board plus the X-NUCLEO-IDB05A1 or the X-NUCLEO-BNRG2A1
 
   You can use a generic BLE central app, like LightBlue (iOS and Android) or
   nRF Connect (Android), to interact with the services and characteristics
@@ -22,8 +22,8 @@
 SPIClass SpiHCI(PC3, PD3, PD1);
 HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_1S, PD0, PD4, PA8, 1000000, SPI_MODE1);
 BLELocalDevice BLE(&HCISpiTransport);
-#elif defined(ARDUINO_DISCO_L475VG_IOT)
-/* B-L475E-IOT01A1 */
+#elif defined(ARDUINO_DISCO_L475VG_IOT) || defined(ARDUINO_B_L4S5I_IOT01A)
+/* B-L475E-IOT01A1 or B_L4S5I_IOT01A */
 SPIClass SpiHCI(PC12, PC11, PC10);
 HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_RF, PD13, PE6, PA8, 8000000, SPI_MODE0);
 BLELocalDevice BLE(&HCISpiTransport);

--- a/examples/Peripheral/LED/LED.ino
+++ b/examples/Peripheral/LED/LED.ino
@@ -5,7 +5,7 @@
   characteristic to control an LED.
 
   The circuit:
-  - STEVAL-MKSBOX1V1, B-L475E-IOT01A1, or a Nucleo board plus the X-NUCLEO-IDB05A1 or the X-NUCLEO-BNRG2A1
+  - STEVAL-MKSBOX1V1, B-L475E-IOT01A1, B_L4S5I_IOT01A, or a Nucleo board plus the X-NUCLEO-IDB05A1 or the X-NUCLEO-BNRG2A1
 
   You can use a generic BLE central app, like LightBlue (iOS and Android) or
   nRF Connect (Android), to interact with the services and characteristics
@@ -20,8 +20,8 @@
 SPIClass SpiHCI(PC3, PD3, PD1);
 HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_1S, PD0, PD4, PA8, 1000000, SPI_MODE1);
 BLELocalDevice BLE(&HCISpiTransport);
-#elif defined(ARDUINO_DISCO_L475VG_IOT)
-/* B-L475E-IOT01A1 */
+#elif defined(ARDUINO_DISCO_L475VG_IOT) || defined(ARDUINO_B_L4S5I_IOT01A)
+/* B-L475E-IOT01A1 or B_L4S5I_IOT01A */
 SPIClass SpiHCI(PC12, PC11, PC10);
 HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_RF, PD13, PE6, PA8, 8000000, SPI_MODE0);
 BLELocalDevice BLE(&HCISpiTransport);


### PR DESCRIPTION
B_L4S5I_IOT01A is using same pins for Bluetooth and SPI3
as the discovery kit B-L475E-IOT01A1

Signed-off-by: Francois Ramu <francois.ramu@st.com>