### PR TITLE
Use B_L475E_IOT01A official name

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -9,7 +9,7 @@ jobs:
        fqbn: [
          '"STM32:stm32:Eval:pnum=STEVAL_MKSBOX1V1,usb=CDCgen" "https://github.com/stm32duino/BoardManagerFiles/raw/master/STM32/package_stm_index.json"',
          '"STM32:stm32:Nucleo_64:pnum=NUCLEO_L476RG" "https://github.com/stm32duino/BoardManagerFiles/raw/master/STM32/package_stm_index.json"',
-         '"STM32:stm32:Disco:pnum=DISCO_L475VG_IOT" "https://github.com/stm32duino/BoardManagerFiles/raw/master/STM32/package_stm_index.json"'
+         '"STM32:stm32:Disco:pnum=B_L475E_IOT01A" "https://github.com/stm32duino/BoardManagerFiles/raw/master/STM32/package_stm_index.json"'
        ]
 
    steps:

--- a/examples/Central/LedControl/LedControl.ino
+++ b/examples/Central/LedControl/LedControl.ino
@@ -34,7 +34,7 @@ BLELocalDevice BLEObj(&HCISpiTransport);
 BLELocalDevice& BLE = BLEObj;
 #endif
 const int buttonPin = PC13; // set buttonPin to digital pin PC13
-#elif defined(ARDUINO_PNUCLEO_WB55RG)
+#elif defined(ARDUINO_P_NUCLEO_WB55RG)
 /* PNUCLEO_WB55RG */
 HCISharedMemTransportClass HCISharedMemTransport;
 #if !defined(FAKE_BLELOCALDEVICE)

--- a/examples/Central/LedControl/LedControl.ino
+++ b/examples/Central/LedControl/LedControl.ino
@@ -25,7 +25,7 @@ BLELocalDevice BLEObj(&HCISpiTransport);
 BLELocalDevice& BLE = BLEObj;
 #endif
 const int buttonPin = PG1; // set buttonPin to digital pin PG1
-#elif defined(ARDUINO_DISCO_L475VG_IOT) || defined(ARDUINO_B_L4S5I_IOT01A)
+#elif defined(ARDUINO_B_L475E_IOT01A) || defined(ARDUINO_B_L4S5I_IOT01A)
 /* B-L475E-IOT01A1 or B_L4S5I_IOT01A */
 SPIClass SpiHCI(PC12, PC11, PC10);
 HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_RF, PD13, PE6, PA8, 8000000, SPI_MODE0);

--- a/examples/Central/PeripheralExplorer/PeripheralExplorer.ino
+++ b/examples/Central/PeripheralExplorer/PeripheralExplorer.ino
@@ -23,7 +23,7 @@ HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_1S, PD0, PD4, PA8, 1000000, 
 BLELocalDevice BLEObj(&HCISpiTransport);
 BLELocalDevice& BLE = BLEObj;
 #endif
-#elif defined(ARDUINO_DISCO_L475VG_IOT) || defined(ARDUINO_B_L4S5I_IOT01A)
+#elif defined(ARDUINO_B_L475E_IOT01A) || defined(ARDUINO_B_L4S5I_IOT01A)
 /* B-L475E-IOT01A1 or B_L4S5I_IOT01A */
 SPIClass SpiHCI(PC12, PC11, PC10);
 HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_RF, PD13, PE6, PA8, 8000000, SPI_MODE0);

--- a/examples/Central/PeripheralExplorer/PeripheralExplorer.ino
+++ b/examples/Central/PeripheralExplorer/PeripheralExplorer.ino
@@ -31,7 +31,7 @@ HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_RF, PD13, PE6, PA8, 8000000,
 BLELocalDevice BLEObj(&HCISpiTransport);
 BLELocalDevice& BLE = BLEObj;
 #endif
-#elif defined(ARDUINO_PNUCLEO_WB55RG)
+#elif defined(ARDUINO_P_NUCLEO_WB55RG)
 /* PNUCLEO_WB55RG */
 HCISharedMemTransportClass HCISharedMemTransport;
 #if !defined(FAKE_BLELOCALDEVICE)

--- a/examples/Central/Scan/Scan.ino
+++ b/examples/Central/Scan/Scan.ino
@@ -20,7 +20,7 @@ HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_1S, PD0, PD4, PA8, 1000000, 
 BLELocalDevice BLEObj(&HCISpiTransport);
 BLELocalDevice& BLE = BLEObj;
 #endif
-#elif defined(ARDUINO_DISCO_L475VG_IOT) || defined(ARDUINO_B_L4S5I_IOT01A)
+#elif defined(ARDUINO_B_L475E_IOT01A) || defined(ARDUINO_B_L4S5I_IOT01A)
 /* B-L475E-IOT01A1 or B_L4S5I_IOT01A */
 SPIClass SpiHCI(PC12, PC11, PC10);
 HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_RF, PD13, PE6, PA8, 8000000, SPI_MODE0);

--- a/examples/Central/Scan/Scan.ino
+++ b/examples/Central/Scan/Scan.ino
@@ -28,7 +28,7 @@ HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_RF, PD13, PE6, PA8, 8000000,
 BLELocalDevice BLEObj(&HCISpiTransport);
 BLELocalDevice& BLE = BLEObj;
 #endif
-#elif defined(ARDUINO_PNUCLEO_WB55RG)
+#elif defined(ARDUINO_P_NUCLEO_WB55RG)
 /* PNUCLEO_WB55RG */
 HCISharedMemTransportClass HCISharedMemTransport;
 #if !defined(FAKE_BLELOCALDEVICE)

--- a/examples/Central/ScanCallback/ScanCallback.ino
+++ b/examples/Central/ScanCallback/ScanCallback.ino
@@ -30,7 +30,7 @@ HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_RF, PD13, PE6, PA8, 8000000,
 BLELocalDevice BLEObj(&HCISpiTransport);
 BLELocalDevice& BLE = BLEObj;
 #endif
-#elif defined(ARDUINO_PNUCLEO_WB55RG)
+#elif defined(ARDUINO_P_NUCLEO_WB55RG)
 /* PNUCLEO_WB55RG */
 HCISharedMemTransportClass HCISharedMemTransport;
 #if !defined(FAKE_BLELOCALDEVICE)

--- a/examples/Central/ScanCallback/ScanCallback.ino
+++ b/examples/Central/ScanCallback/ScanCallback.ino
@@ -22,7 +22,7 @@ HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_1S, PD0, PD4, PA8, 1000000, 
 BLELocalDevice BLEObj(&HCISpiTransport);
 BLELocalDevice& BLE = BLEObj;
 #endif
-#elif defined(ARDUINO_DISCO_L475VG_IOT) || defined(ARDUINO_B_L4S5I_IOT01A)
+#elif defined(ARDUINO_B_L475E_IOT01A) || defined(ARDUINO_B_L4S5I_IOT01A)
 /* B-L475E-IOT01A1 or B_L4S5I_IOT01A */
 SPIClass SpiHCI(PC12, PC11, PC10);
 HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_RF, PD13, PE6, PA8, 8000000, SPI_MODE0);

--- a/examples/Central/SensorTagButton/SensorTagButton.ino
+++ b/examples/Central/SensorTagButton/SensorTagButton.ino
@@ -24,7 +24,7 @@ HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_1S, PD0, PD4, PA8, 1000000, 
 BLELocalDevice BLEObj(&HCISpiTransport);
 BLELocalDevice& BLE = BLEObj;
 #endif
-#elif defined(ARDUINO_DISCO_L475VG_IOT) || defined(ARDUINO_B_L4S5I_IOT01A)
+#elif defined(ARDUINO_B_L475E_IOT01A) || defined(ARDUINO_B_L4S5I_IOT01A)
 /* B-L475E-IOT01A1 or B_L4S5I_IOT01A */
 SPIClass SpiHCI(PC12, PC11, PC10);
 HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_RF, PD13, PE6, PA8, 8000000, SPI_MODE0);

--- a/examples/Central/SensorTagButton/SensorTagButton.ino
+++ b/examples/Central/SensorTagButton/SensorTagButton.ino
@@ -32,7 +32,7 @@ HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_RF, PD13, PE6, PA8, 8000000,
 BLELocalDevice BLEObj(&HCISpiTransport);
 BLELocalDevice& BLE = BLEObj;
 #endif
-#elif defined(ARDUINO_PNUCLEO_WB55RG)
+#elif defined(ARDUINO_P_NUCLEO_WB55RG)
 /* PNUCLEO_WB55RG */
 HCISharedMemTransportClass HCISharedMemTransport;
 #if !defined(FAKE_BLELOCALDEVICE)

--- a/examples/Peripheral/ButtonLED/ButtonLED.ino
+++ b/examples/Peripheral/ButtonLED/ButtonLED.ino
@@ -26,7 +26,7 @@ BLELocalDevice BLEObj(&HCISpiTransport);
 BLELocalDevice& BLE = BLEObj;
 #endif
 const int buttonPin = PG1; // set buttonPin to digital pin PG1
-#elif defined(ARDUINO_DISCO_L475VG_IOT) || defined(ARDUINO_B_L4S5I_IOT01A)
+#elif defined(ARDUINO_B_L475E_IOT01A) || defined(ARDUINO_B_L4S5I_IOT01A)
 /* B-L475E-IOT01A1 or B_L4S5I_IOT01A */
 SPIClass SpiHCI(PC12, PC11, PC10);
 HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_RF, PD13, PE6, PA8, 8000000, SPI_MODE0);

--- a/examples/Peripheral/ButtonLED/ButtonLED.ino
+++ b/examples/Peripheral/ButtonLED/ButtonLED.ino
@@ -35,7 +35,7 @@ BLELocalDevice BLEObj(&HCISpiTransport);
 BLELocalDevice& BLE = BLEObj;
 #endif
 const int buttonPin = PC13; // set buttonPin to digital pin PC13
-#elif defined(ARDUINO_PNUCLEO_WB55RG)
+#elif defined(ARDUINO_P_NUCLEO_WB55RG)
 /* PNUCLEO_WB55RG */
 HCISharedMemTransportClass HCISharedMemTransport;
 #if !defined(FAKE_BLELOCALDEVICE)

--- a/examples/Peripheral/CallbackLED/CallbackLED.ino
+++ b/examples/Peripheral/CallbackLED/CallbackLED.ino
@@ -33,7 +33,7 @@ HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_RF, PD13, PE6, PA8, 8000000,
 BLELocalDevice BLEObj(&HCISpiTransport);
 BLELocalDevice& BLE = BLEObj;
 #endif
-#elif defined(ARDUINO_PNUCLEO_WB55RG)
+#elif defined(ARDUINO_P_NUCLEO_WB55RG)
 /* PNUCLEO_WB55RG */
 HCISharedMemTransportClass HCISharedMemTransport;
 #if !defined(FAKE_BLELOCALDEVICE)

--- a/examples/Peripheral/CallbackLED/CallbackLED.ino
+++ b/examples/Peripheral/CallbackLED/CallbackLED.ino
@@ -25,7 +25,7 @@ HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_1S, PD0, PD4, PA8, 1000000, 
 BLELocalDevice BLEObj(&HCISpiTransport);
 BLELocalDevice& BLE = BLEObj;
 #endif
-#elif defined(ARDUINO_DISCO_L475VG_IOT) || defined(ARDUINO_B_L4S5I_IOT01A)
+#elif defined(ARDUINO_B_L475E_IOT01A) || defined(ARDUINO_B_L4S5I_IOT01A)
 /* B-L475E-IOT01A1 or B_L4S5I_IOT01A */
 SPIClass SpiHCI(PC12, PC11, PC10);
 HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_RF, PD13, PE6, PA8, 8000000, SPI_MODE0);

--- a/examples/Peripheral/LED/LED.ino
+++ b/examples/Peripheral/LED/LED.ino
@@ -23,7 +23,7 @@ HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_1S, PD0, PD4, PA8, 1000000, 
 BLELocalDevice BLEObj(&HCISpiTransport);
 BLELocalDevice& BLE = BLEObj;
 #endif
-#elif defined(ARDUINO_DISCO_L475VG_IOT) || defined(ARDUINO_B_L4S5I_IOT01A)
+#elif defined(ARDUINO_B_L475E_IOT01A) || defined(ARDUINO_B_L4S5I_IOT01A)
 /* B-L475E-IOT01A1 or B_L4S5I_IOT01A */
 SPIClass SpiHCI(PC12, PC11, PC10);
 HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_RF, PD13, PE6, PA8, 8000000, SPI_MODE0);

--- a/examples/Peripheral/LED/LED.ino
+++ b/examples/Peripheral/LED/LED.ino
@@ -31,7 +31,7 @@ HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_RF, PD13, PE6, PA8, 8000000,
 BLELocalDevice BLEObj(&HCISpiTransport);
 BLELocalDevice& BLE = BLEObj;
 #endif
-#elif defined(ARDUINO_PNUCLEO_WB55RG)
+#elif defined(ARDUINO_P_NUCLEO_WB55RG)
 /* PNUCLEO_WB55RG */
 HCISharedMemTransportClass HCISharedMemTransport;
 #if !defined(FAKE_BLELOCALDEVICE)


### PR DESCRIPTION
Since STM32 core version 2.0.0, the board name has been updated from DISCO_L475VG_IOT to B_L475E_IOT01A.

Update also P_NUCLEO_WB55RG.