### PR TITLE
Debug HCI frames only with PRINT_HCI_INFO defined

### DIFF
--- a/src/utility/HCI.cpp
+++ b/src/utility/HCI.cpp
@@ -649,6 +649,7 @@ void HCIClass::handleEventPkt(uint8_t /*plen*/, uint8_t pdata[])
 
 void HCIClass::dumpPkt(const char* prefix, uint8_t plen, uint8_t pdata[])
 {
+#if defined(PRINT_HCI_INFO)
   if (_debug) {
     _debug->print(prefix);
 
@@ -665,6 +666,7 @@ void HCIClass::dumpPkt(const char* prefix, uint8_t plen, uint8_t pdata[])
     _debug->println();
     _debug->flush();
   }
+#endif /*(PRINT_HCI_INFO)*/
 }
 
 void HCIClass::setTransport(HCITransportInterface *HCITransport)


### PR DESCRIPTION
This avoids dumping HCI packets on the console as soon as the serial link is enabled.
In some situations, when the serial trace is on, all the HCI traces are not useful.
The  **PRINT_HCI_INFO** is defined to dump packets only when needed.

Signed-off-by: Francois Ramu <francois.ramu@st.com>