### PR TITLE
Timeout returned when configuring BLE stack for SharedMem transport

### DIFF
--- a/src/utility/STM32Cube_FW/shci_tl.c
+++ b/src/utility/STM32Cube_FW/shci_tl.c
@@ -21,6 +21,8 @@
 /* Includes ------------------------------------------------------------------*/
 #include "stm32_wpan_common.h"
 
+#include <Arduino.h>
+
 #include "stm_list.h"
 #include "shci_tl.h"
 #include "stm32_def.h"
@@ -323,11 +325,12 @@ static void OutputEvtTrace(TL_EvtPacket_t *phcievtbuffer)
 /* Weak implementation ----------------------------------------------------------------*/
 __WEAK void shci_cmd_resp_wait(uint32_t timeout)
 {
-  (void)timeout;
-
   CmdRspStatusFlag = SHCI_TL_CMD_RESP_WAIT;
-  while (CmdRspStatusFlag != SHCI_TL_CMD_RESP_RELEASE);
-
+  for (unsigned long start = millis(); (millis() - start) < timeout;) {
+    if (CmdRspStatusFlag == SHCI_TL_CMD_RESP_RELEASE) {
+      break;
+    }
+  }
   return;
 }
 


### PR DESCRIPTION
Waiting for the CMD response requires a timeout to return when the response is too long.
This part was missing in the BLE SharedMem transport for the stm32wb55. This is now done including a return on timeout in the `shci_cmd_resp_wait` function.
It could also happen that the BLE stack fails during the init phase. This was the case when compiling with non-debug options.
To avoid this deadlock, the CmdRspStatusFlag value must not be optimzed with a volatile value.