### PR TITLE
Set a bd address from OTP for the BLE device stm32wb55

### DIFF
--- a/src/utility/HCISharedMemTransport.cpp
+++ b/src/utility/HCISharedMemTransport.cpp
@@ -20,6 +20,7 @@
 
 #include "HCISharedMemTransport.h"
 #include "STM32Cube_FW/hw.h"
+#include "otp.h"
 
 /* Private variables ---------------------------------------------------------*/
 PLACE_IN_SECTION("MB_MEM1") ALIGN(4) static TL_CmdPacket_t BleCmdBuffer;
@@ -338,8 +339,13 @@ static bool get_bd_address(uint8_t *bd_addr)
 
     bd_found = true;
   } else {
-    bd_addr = NULL;
-    bd_found = false;
+    OTP_BT_t *p_otp = (OTP_BT_t *)OTP_Read(0);
+    if (p_otp) {
+      memcpy(bd_addr, p_otp->bd_address, CONFIG_DATA_PUBADDR_LEN);
+      bd_found = true;
+    } else {
+      bd_found = false;
+    }
   }
 
   return bd_found;


### PR DESCRIPTION
In case the bd address cannot be computed from the flash
then the otp is read to provide a bd address.

Requires the commit` [WB] Move OTP interface as a bsp` ( d2a731a48ffee938116650fa973f184d1ce2543d) from https://github.com/stm32duino/Arduino_Core_STM32/pull/1291

Signed-off-by: Francois Ramu <francois.ramu@st.com>