### PR TITLE
examples: add STM32WB5MM-DK support

### DIFF
--- a/examples/Central/LedControl/LedControl.ino
+++ b/examples/Central/LedControl/LedControl.ino
@@ -34,8 +34,7 @@ BLELocalDevice BLEObj(&HCISpiTransport);
 BLELocalDevice& BLE = BLEObj;
 #endif
 const int buttonPin = PC13; // set buttonPin to digital pin PC13
-#elif defined(ARDUINO_P_NUCLEO_WB55RG)
-/* PNUCLEO_WB55RG */
+#elif defined(ARDUINO_P_NUCLEO_WB55RG) || defined(ARDUINO_STM32WB5MM_DK)
 HCISharedMemTransportClass HCISharedMemTransport;
 #if !defined(FAKE_BLELOCALDEVICE)
 BLELocalDevice BLEObj(&HCISharedMemTransport);

--- a/examples/Central/PeripheralExplorer/PeripheralExplorer.ino
+++ b/examples/Central/PeripheralExplorer/PeripheralExplorer.ino
@@ -31,8 +31,7 @@ HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_RF, PD13, PE6, PA8, 8000000,
 BLELocalDevice BLEObj(&HCISpiTransport);
 BLELocalDevice& BLE = BLEObj;
 #endif
-#elif defined(ARDUINO_P_NUCLEO_WB55RG)
-/* PNUCLEO_WB55RG */
+#elif defined(ARDUINO_P_NUCLEO_WB55RG) || defined(ARDUINO_STM32WB5MM_DK)
 HCISharedMemTransportClass HCISharedMemTransport;
 #if !defined(FAKE_BLELOCALDEVICE)
 BLELocalDevice BLEObj(&HCISharedMemTransport);

--- a/examples/Central/Scan/Scan.ino
+++ b/examples/Central/Scan/Scan.ino
@@ -28,8 +28,7 @@ HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_RF, PD13, PE6, PA8, 8000000,
 BLELocalDevice BLEObj(&HCISpiTransport);
 BLELocalDevice& BLE = BLEObj;
 #endif
-#elif defined(ARDUINO_P_NUCLEO_WB55RG)
-/* PNUCLEO_WB55RG */
+#elif defined(ARDUINO_P_NUCLEO_WB55RG) || defined(ARDUINO_STM32WB5MM_DK)
 HCISharedMemTransportClass HCISharedMemTransport;
 #if !defined(FAKE_BLELOCALDEVICE)
 BLELocalDevice BLEObj(&HCISharedMemTransport);

--- a/examples/Central/ScanCallback/ScanCallback.ino
+++ b/examples/Central/ScanCallback/ScanCallback.ino
@@ -30,8 +30,7 @@ HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_RF, PD13, PE6, PA8, 8000000,
 BLELocalDevice BLEObj(&HCISpiTransport);
 BLELocalDevice& BLE = BLEObj;
 #endif
-#elif defined(ARDUINO_P_NUCLEO_WB55RG)
-/* PNUCLEO_WB55RG */
+#elif defined(ARDUINO_P_NUCLEO_WB55RG) || defined(ARDUINO_STM32WB5MM_DK)
 HCISharedMemTransportClass HCISharedMemTransport;
 #if !defined(FAKE_BLELOCALDEVICE)
 BLELocalDevice BLEObj(&HCISharedMemTransport);

--- a/examples/Central/SensorTagButton/SensorTagButton.ino
+++ b/examples/Central/SensorTagButton/SensorTagButton.ino
@@ -32,8 +32,7 @@ HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_RF, PD13, PE6, PA8, 8000000,
 BLELocalDevice BLEObj(&HCISpiTransport);
 BLELocalDevice& BLE = BLEObj;
 #endif
-#elif defined(ARDUINO_P_NUCLEO_WB55RG)
-/* PNUCLEO_WB55RG */
+#elif defined(ARDUINO_P_NUCLEO_WB55RG) || defined(ARDUINO_STM32WB5MM_DK)
 HCISharedMemTransportClass HCISharedMemTransport;
 #if !defined(FAKE_BLELOCALDEVICE)
 BLELocalDevice BLEObj(&HCISharedMemTransport);

--- a/examples/Peripheral/ButtonLED/ButtonLED.ino
+++ b/examples/Peripheral/ButtonLED/ButtonLED.ino
@@ -35,8 +35,7 @@ BLELocalDevice BLEObj(&HCISpiTransport);
 BLELocalDevice& BLE = BLEObj;
 #endif
 const int buttonPin = PC13; // set buttonPin to digital pin PC13
-#elif defined(ARDUINO_P_NUCLEO_WB55RG)
-/* PNUCLEO_WB55RG */
+#elif defined(ARDUINO_P_NUCLEO_WB55RG) || defined(ARDUINO_STM32WB5MM_DK)
 HCISharedMemTransportClass HCISharedMemTransport;
 #if !defined(FAKE_BLELOCALDEVICE)
 BLELocalDevice BLEObj(&HCISharedMemTransport);

--- a/examples/Peripheral/CallbackLED/CallbackLED.ino
+++ b/examples/Peripheral/CallbackLED/CallbackLED.ino
@@ -33,8 +33,7 @@ HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_RF, PD13, PE6, PA8, 8000000,
 BLELocalDevice BLEObj(&HCISpiTransport);
 BLELocalDevice& BLE = BLEObj;
 #endif
-#elif defined(ARDUINO_P_NUCLEO_WB55RG)
-/* PNUCLEO_WB55RG */
+#elif defined(ARDUINO_P_NUCLEO_WB55RG) || defined(ARDUINO_STM32WB5MM_DK)
 HCISharedMemTransportClass HCISharedMemTransport;
 #if !defined(FAKE_BLELOCALDEVICE)
 BLELocalDevice BLEObj(&HCISharedMemTransport);

--- a/examples/Peripheral/LED/LED.ino
+++ b/examples/Peripheral/LED/LED.ino
@@ -31,8 +31,7 @@ HCISpiTransportClass HCISpiTransport(SpiHCI, SPBTLE_RF, PD13, PE6, PA8, 8000000,
 BLELocalDevice BLEObj(&HCISpiTransport);
 BLELocalDevice& BLE = BLEObj;
 #endif
-#elif defined(ARDUINO_P_NUCLEO_WB55RG)
-/* PNUCLEO_WB55RG */
+#elif defined(ARDUINO_P_NUCLEO_WB55RG) || defined(ARDUINO_STM32WB5MM_DK)
 HCISharedMemTransportClass HCISharedMemTransport;
 #if !defined(FAKE_BLELOCALDEVICE)
 BLELocalDevice BLEObj(&HCISharedMemTransport);

--- a/src/utility/HCISharedMemTransport.h
+++ b/src/utility/HCISharedMemTransport.h
@@ -23,7 +23,6 @@
 #include "HCITransport.h"
 
 /* STM32WB include files */
-#include "stm32wb55xx.h"
 #include "stm32wbxx_ll_rcc.h"
 #include "stm32wbxx_ll_ipcc.h"
 #include "stm32wbxx_ll_system.h"


### PR DESCRIPTION
This PR also includes a fix to remove specific include.  Correct CMSIS device header already included by the core.
    