### PR TITLE
Update STM32Cube_FW from Cube version v1.14.0

### DIFF
--- a/extras/STM32Cube_FW/0001-chore-clean-up-and-adapt-STM32Cube_FW-sources-for-ST.patch
+++ b/extras/STM32Cube_FW/0001-chore-clean-up-and-adapt-STM32Cube_FW-sources-for-ST.patch
@@ -1,29 +1,28 @@
-From 6fcfc029ba21a3674456a12032720bff6ecfe27d Mon Sep 17 00:00:00 2001
-From: Alexandre Bourdiol <alexandre.bourdiol@st.com>
-Date: Mon, 6 Dec 2021 11:08:32 +0100
+From 5c49396dbc2f435158b6d6a2d8b21a04902cadd5 Mon Sep 17 00:00:00 2001
+From: TLIG Dhaou <dhaou.tlig-ext@st.com>
+Date: Tue, 26 Jul 2022 14:06:34 +0200
 Subject: [PATCH 1/4] chore: clean up and adapt STM32Cube_FW sources for
  STM32duino
 
-Signed-off-by: Frederic Pillon <frederic.pillon@st.com>
-Signed-off-by: Alexandre Bourdiol <alexandre.bourdiol@st.com>
+Signed-off-by: TLIG Dhaou <dhaou.tlig-ext@st.com>
 ---
- src/utility/STM32Cube_FW/app_conf_default.h  | 422 +------------------
- src/utility/STM32Cube_FW/ble_bufsize.h       |  13 +-
- src/utility/STM32Cube_FW/hw.h                |  28 +-
- src/utility/STM32Cube_FW/hw_ipcc.c           | 184 +-------
+ src/utility/STM32Cube_FW/app_conf_default.h  | 427 +------------------
+ src/utility/STM32Cube_FW/ble_bufsize.h       |  10 +
+ src/utility/STM32Cube_FW/hw.h                |  27 +-
+ src/utility/STM32Cube_FW/hw_ipcc.c           | 168 +-------
  src/utility/STM32Cube_FW/mbox_def.h          |  34 --
- src/utility/STM32Cube_FW/shci.c              |  40 +-
- src/utility/STM32Cube_FW/shci.h              |  47 +--
- src/utility/STM32Cube_FW/shci_tl.c           |  19 +-
- src/utility/STM32Cube_FW/stm32_wpan_common.h |  39 +-
+ src/utility/STM32Cube_FW/shci.c              |  39 +-
+ src/utility/STM32Cube_FW/shci.h              |  53 +--
+ src/utility/STM32Cube_FW/shci_tl.c           |  20 +-
+ src/utility/STM32Cube_FW/stm32_wpan_common.h |  25 +-
  src/utility/STM32Cube_FW/stm_list.c          |  11 +-
  src/utility/STM32Cube_FW/stm_list.h          |   4 +-
  src/utility/STM32Cube_FW/tl.h                |  33 --
- src/utility/STM32Cube_FW/tl_mbox.c           | 144 +------
- 13 files changed, 94 insertions(+), 924 deletions(-)
+ src/utility/STM32Cube_FW/tl_mbox.c           | 143 +------
+ 13 files changed, 93 insertions(+), 901 deletions(-)
 
 diff --git a/src/utility/STM32Cube_FW/app_conf_default.h b/src/utility/STM32Cube_FW/app_conf_default.h
-index 7ebc65a..4f300e0 100644
+index c63c66e..1d5e06a 100644
 --- a/src/utility/STM32Cube_FW/app_conf_default.h
 +++ b/src/utility/STM32Cube_FW/app_conf_default.h
 @@ -1,4 +1,3 @@
@@ -31,7 +30,7 @@ index 7ebc65a..4f300e0 100644
  /**
    ******************************************************************************
    * @file    app_conf.h
-@@ -16,94 +15,36 @@
+@@ -16,94 +15,40 @@
    *
    ******************************************************************************
    */
@@ -53,39 +52,39 @@ index 7ebc65a..4f300e0 100644
 -/**
 - * Define Secure Connections Support
 - */
--#define CFG_SECURE_NOT_SUPPORTED       (0x00)
--#define CFG_SECURE_OPTIONAL            (0x01)
--#define CFG_SECURE_MANDATORY           (0x02)
+-#define CFG_SECURE_NOT_SUPPORTED              (0x00)
+-#define CFG_SECURE_OPTIONAL                   (0x01)
+-#define CFG_SECURE_MANDATORY                  (0x02)
 -
--#define CFG_SC_SUPPORT                 CFG_SECURE_OPTIONAL
+-#define CFG_SC_SUPPORT                        CFG_SECURE_OPTIONAL
+-
+ /**
+  * Define Keypress Notification Support
+  */
+-#define CFG_KEYPRESS_NOT_SUPPORTED            (0x00)
+-#define CFG_KEYPRESS_SUPPORTED                (0x01)
+-
+-#define CFG_KEYPRESS_NOTIFICATION_SUPPORT     CFG_KEYPRESS_NOT_SUPPORTED
 -
 -/**
-- * Define Keypress Notification Support
+- * Numeric Comparison Answers
 - */
--#define CFG_KEYPRESS_NOT_SUPPORTED      (0x00)
--#define CFG_KEYPRESS_SUPPORTED          (0x01)
+-#define YES (0x01)
+-#define NO  (0x00)
 +/**< generic parameters ******************************************************/
 +/* HCI related defines */
  
--#define CFG_KEYPRESS_NOTIFICATION_SUPPORT             CFG_KEYPRESS_NOT_SUPPORTED
+-/**
+- * Device name configuration for Generic Access Service
+- */
+-#define CFG_GAP_DEVICE_NAME             "TEMPLATE"
+-#define CFG_GAP_DEVICE_NAME_LENGTH      (8)
 +#define ACI_HAL_SET_TX_POWER_LEVEL 0xFC0F
 +#define ACI_WRITE_CONFIG_DATA_OPCODE 0xFC0C
 +#define ACI_READ_CONFIG_DATA_OPCODE 0xFC0D
 +#define MAX_HCI_ACL_PACKET_SIZE (sizeof(TL_PacketHeader_t) + 5 + 251)
 +#define HCI_RESET 0x0C03
  
--/**
-- * Numeric Comparison Answers
-- */
--#define YES (0x01)
--#define NO  (0x00)
--
--/**
-- * Device name configuration for Generic Access Service
-- */
--#define CFG_GAP_DEVICE_NAME             "TEMPLATE"
--#define CFG_GAP_DEVICE_NAME_LENGTH      (8)
--
 -/**
 -*   Identity root key used to derive LTK and CSRK
 -*/
@@ -110,7 +109,7 @@ index 7ebc65a..4f300e0 100644
 -
 -/* USER CODE BEGIN Generic_Parameters */
 -/* USER CODE END Generic_Parameters */
--
+ 
 -/**< specific parameters */
 -/*****************************************************/
 -
@@ -139,9 +138,9 @@ index 7ebc65a..4f300e0 100644
  
  /******************************************************************************
   * BLE Stack
-@@ -152,13 +93,15 @@
+@@ -152,13 +97,15 @@
   * Prepare Write List size in terms of number of packet
-  * This parameter is ignored by the CPU2 when CFG_BLE_OPTIONS is set to 1"
+  * This parameter is ignored by the CPU2 when CFG_BLE_OPTIONS has SHCI_C2_BLE_INIT_OPTIONS_LL_ONLY flag set
   */
 -#define CFG_BLE_PREPARE_WRITE_LIST_SIZE         BLE_PREP_WRITE_X_ATT(CFG_BLE_MAX_ATT_MTU)
 +// #define CFG_BLE_PREPARE_WRITE_LIST_SIZE         BLE_PREP_WRITE_X_ATT(CFG_BLE_MAX_ATT_MTU)
@@ -149,7 +148,7 @@ index 7ebc65a..4f300e0 100644
  
  /**
   * Number of allocated memory blocks
-  * This parameter is overwritten by the CPU2 with an hardcoded optimal value when the parameter when CFG_BLE_OPTIONS is set to 1
+  * This parameter is overwritten by the CPU2 with an hardcoded optimal value when the parameter CFG_BLE_OPTIONS has SHCI_C2_BLE_INIT_OPTIONS_LL_ONLY flag set
   */
 -#define CFG_BLE_MBLOCK_COUNT            (BLE_MBLOCKS_CALC(CFG_BLE_PREPARE_WRITE_LIST_SIZE, CFG_BLE_MAX_ATT_MTU, CFG_BLE_NUM_LINK))
 +// #define CFG_BLE_MBLOCK_COUNT            (BLE_MBLOCKS_CALC(CFG_BLE_PREPARE_WRITE_LIST_SIZE, CFG_BLE_MAX_ATT_MTU, CFG_BLE_NUM_LINK))
@@ -157,19 +156,20 @@ index 7ebc65a..4f300e0 100644
  
  /**
   * Enable or disable the Extended Packet length feature. Valid values are 0 or 1.
-@@ -236,7 +179,7 @@
+@@ -241,7 +188,7 @@
   *          0: LE Power Class 2-3
   * other bits: reserved (shall be set to 0)
   */
--#define CFG_BLE_OPTIONS  (SHCI_C2_BLE_INIT_OPTIONS_LL_HOST | SHCI_C2_BLE_INIT_OPTIONS_WITH_SVC_CHANGE_DESC | SHCI_C2_BLE_INIT_OPTIONS_DEVICE_NAME_RW | SHCI_C2_BLE_INIT_OPTIONS_NO_EXT_ADV | SHCI_C2_BLE_INIT_OPTIONS_NO_CS_ALGO2 | SHCI_C2_BLE_INIT_OPTIONS_POWER_CLASS_2_3)
+-#define CFG_BLE_OPTIONS  (SHCI_C2_BLE_INIT_OPTIONS_LL_HOST | SHCI_C2_BLE_INIT_OPTIONS_WITH_SVC_CHANGE_DESC | SHCI_C2_BLE_INIT_OPTIONS_DEVICE_NAME_RW | SHCI_C2_BLE_INIT_OPTIONS_EXT_ADV | SHCI_C2_BLE_INIT_OPTIONS_CS_ALGO2 | SHCI_C2_BLE_INIT_OPTIONS_POWER_CLASS_2_3)
 +#define CFG_BLE_OPTIONS  (SHCI_C2_BLE_INIT_OPTIONS_LL_ONLY)
  
  #define CFG_BLE_MAX_COC_INITIATOR_NBR   (32)
  
-@@ -256,334 +199,5 @@
+@@ -290,341 +237,5 @@
+   */
  
- #define CFG_BLE_RX_MODEL_CONFIG         SHCI_C2_BLE_INIT_RX_MODEL_AGC_RSSI_LEGACY
- 
+ #define CFG_BLE_RX_PATH_COMPENS    (0)
+-
 -/******************************************************************************
 - * Transport Layer
 - ******************************************************************************/
@@ -206,7 +206,7 @@ index 7ebc65a..4f300e0 100644
 -/**
 - * Select UART interfaces
 - */
--#define CFG_UART_GUI          hw_uart1
+-#define CFG_UART_GUI            hw_uart1
 -#define CFG_DEBUG_TRACE_UART    0
 -/******************************************************************************
 - * USB interface
@@ -276,10 +276,10 @@ index 7ebc65a..4f300e0 100644
 - * It divides the RTC CLK by 16
 - */
 -
--#define CFG_RTCCLK_DIV  (16)
--#define CFG_RTC_WUCKSEL_DIVIDER (0)
--#define CFG_RTC_ASYNCH_PRESCALER (0x0F)
--#define CFG_RTC_SYNCH_PRESCALER (0x7FFF)
+-#define CFG_RTCCLK_DIV            (16)
+-#define CFG_RTC_WUCKSEL_DIVIDER   (0)
+-#define CFG_RTC_ASYNCH_PRESCALER  (0x0F)
+-#define CFG_RTC_SYNCH_PRESCALER   (0x7FFF)
 -
 -#else
 -
@@ -370,7 +370,7 @@ index 7ebc65a..4f300e0 100644
 -#if (CFG_DEBUG_TRACE != 0)
 -#undef CFG_LPM_SUPPORTED
 -#undef CFG_DEBUGGER_SUPPORTED
--#define CFG_LPM_SUPPORTED         0
+-#define CFG_LPM_SUPPORTED           0
 -#define CFG_DEBUGGER_SUPPORTED      1
 -#endif
 -
@@ -408,7 +408,7 @@ index 7ebc65a..4f300e0 100644
 - * Only Used if DBG_TRACE_USE_CIRCULAR_QUEUE is defined
 - */
 -#define DBG_TRACE_MSG_QUEUE_SIZE 4096
--#define MAX_DBG_TRACE_MSG_SIZE 1024
+-#define MAX_DBG_TRACE_MSG_SIZE   1024
 -
 -/* USER CODE BEGIN Defines */
 -#define CFG_LED_SUPPORTED         1
@@ -433,31 +433,31 @@ index 7ebc65a..4f300e0 100644
 -/**< Add in that list all tasks that may send a ACI/HCI command */
 -typedef enum
 -{
--    CFG_TASK_BLE_HCI_CMD_ID,
--    CFG_TASK_SYS_HCI_CMD_ID,
--    CFG_TASK_HCI_ACL_DATA_ID,
--    CFG_TASK_SYS_LOCAL_CMD_ID,
--    CFG_TASK_TX_TO_HOST_ID,
--    /* USER CODE BEGIN CFG_Task_Id_With_HCI_Cmd_t */
--    CFG_TASK_SW1_BUTTON_PUSHED_ID,
--    CFG_TASK_SW2_BUTTON_PUSHED_ID,
--    CFG_TASK_SW3_BUTTON_PUSHED_ID,
--    /* USER CODE END CFG_Task_Id_With_HCI_Cmd_t */
--    CFG_LAST_TASK_ID_WITH_HCICMD,                                               /**< Shall be LAST in the list */
+-  CFG_TASK_BLE_HCI_CMD_ID,
+-  CFG_TASK_SYS_HCI_CMD_ID,
+-  CFG_TASK_HCI_ACL_DATA_ID,
+-  CFG_TASK_SYS_LOCAL_CMD_ID,
+-  CFG_TASK_TX_TO_HOST_ID,
+-  /* USER CODE BEGIN CFG_Task_Id_With_HCI_Cmd_t */
+-  CFG_TASK_SW1_BUTTON_PUSHED_ID,
+-  CFG_TASK_SW2_BUTTON_PUSHED_ID,
+-  CFG_TASK_SW3_BUTTON_PUSHED_ID,
+-  /* USER CODE END CFG_Task_Id_With_HCI_Cmd_t */
+-  CFG_LAST_TASK_ID_WITH_HCICMD,                                               /**< Shall be LAST in the list */
 -} CFG_Task_Id_With_HCI_Cmd_t;
 -
 -/**< Add in that list all tasks that never send a ACI/HCI command */
 -typedef enum
 -{
--    CFG_FIRST_TASK_ID_WITH_NO_HCICMD = CFG_LAST_TASK_ID_WITH_HCICMD - 1,        /**< Shall be FIRST in the list */
--    CFG_TASK_SYSTEM_HCI_ASYNCH_EVT_ID,
--    /* USER CODE BEGIN CFG_Task_Id_With_NO_HCI_Cmd_t */
+-  CFG_FIRST_TASK_ID_WITH_NO_HCICMD = CFG_LAST_TASK_ID_WITH_HCICMD - 1,        /**< Shall be FIRST in the list */
+-  CFG_TASK_SYSTEM_HCI_ASYNCH_EVT_ID,
+-  /* USER CODE BEGIN CFG_Task_Id_With_NO_HCI_Cmd_t */
 -
--    /* USER CODE END CFG_Task_Id_With_NO_HCI_Cmd_t */
--    CFG_LAST_TASK_ID_WITHO_NO_HCICMD                                            /**< Shall be LAST in the list */
+-  /* USER CODE END CFG_Task_Id_With_NO_HCI_Cmd_t */
+-  CFG_LAST_TASK_ID_WITH_NO_HCICMD                                            /**< Shall be LAST in the list */
 -} CFG_Task_Id_With_NO_HCI_Cmd_t;
 -
--#define CFG_TASK_NBR    CFG_LAST_TASK_ID_WITHO_NO_HCICMD
+-#define CFG_TASK_NBR    CFG_LAST_TASK_ID_WITH_NO_HCICMD
 -
 -/**
 - * This is the list of priority required by the application
@@ -465,8 +465,10 @@ index 7ebc65a..4f300e0 100644
 - */
 -typedef enum
 -{
--    CFG_SCH_PRIO_0,
--    CFG_PRIO_NBR,
+-  CFG_SCH_PRIO_0,
+-  /* USER CODE BEGIN CFG_SCH_Prio_Id_t */
+-
+-  /* USER CODE END CFG_SCH_Prio_Id_t */
 -} CFG_SCH_Prio_Id_t;
 -
 -/**
@@ -474,7 +476,10 @@ index 7ebc65a..4f300e0 100644
 - */
 -typedef enum
 -{
--    CFG_IDLEEVT_SYSTEM_HCI_CMD_EVT_RSP_ID,
+-  CFG_IDLEEVT_SYSTEM_HCI_CMD_EVT_RSP_ID,
+-  /* USER CODE BEGIN CFG_IdleEvt_Id_t */
+-
+-  /* USER CODE END CFG_IdleEvt_Id_t */
 -} CFG_IdleEvt_Id_t;
 -
 -/******************************************************************************
@@ -486,11 +491,11 @@ index 7ebc65a..4f300e0 100644
 - */
 -typedef enum
 -{
--    CFG_LPM_APP,
--    CFG_LPM_APP_BLE,
--    /* USER CODE BEGIN CFG_LPM_Id_t */
+-  CFG_LPM_APP,
+-  CFG_LPM_APP_BLE,
+-  /* USER CODE BEGIN CFG_LPM_Id_t */
 -
--    /* USER CODE END CFG_LPM_Id_t */
+-  /* USER CODE END CFG_LPM_Id_t */
 -} CFG_LPM_Id_t;
 -
 -/******************************************************************************
@@ -499,13 +504,15 @@ index 7ebc65a..4f300e0 100644
 -#define CFG_OTP_BASE_ADDRESS    OTP_AREA_BASE
 -
 -#define CFG_OTP_END_ADRESS      OTP_AREA_END_ADDR
+-
+-#endif /*APP_CONF_H */
++ #endif /*APP_CONF_H */
  
- #endif /*APP_CONF_H */
 diff --git a/src/utility/STM32Cube_FW/ble_bufsize.h b/src/utility/STM32Cube_FW/ble_bufsize.h
-index ba9c4d3..73b7887 100644
+index 0f0f419..021d9e4 100644
 --- a/src/utility/STM32Cube_FW/ble_bufsize.h
 +++ b/src/utility/STM32Cube_FW/ble_bufsize.h
-@@ -75,17 +75,24 @@
+@@ -75,17 +75,27 @@
            ((pw) + MAX(BLE_MEM_BLOCK_X_MTU(mtu, n_link), \
                        BLE_MBLOCKS_SECURE_CONNECTIONS))
  
@@ -518,26 +525,26 @@ index ba9c4d3..73b7887 100644
 +
  /*
   * BLE_FIXED_BUFFER_SIZE_BYTES:
-- * A part of the RAM, is dinamically allocated by initilizing all the pointers
-+ * A part of the RAM, is dynamically allocated by initializing all the pointers 
+  * A part of the RAM, is dinamically allocated by initilizing all the pointers
++ * A part of the RAM, is dynamically allocated by initializing all the pointers
   * defined in a global context variable "mem_alloc_ctx_p".
   * This initialization is made in the Dynamic_allocator functions, which 
-- * assing a portion of RAM given by the external application to the above
+  * assing a portion of RAM given by the external application to the above
 + * assign a portion of RAM given by the external application to the above
   * mentioned "global pointers".
   *
   * The size of this Dynamic RAM is made of 2 main components: 
   * - a part that is parameters-dependent (num of links, GATT buffers, ...),
-- *   and which value is explicited by the following macro;
+  *   and which value is explicited by the following macro;
 + *   and which value is defined by the following macro;
   * - a part, that may be considered "fixed", i.e. independent from the above
   *   mentioned parameters.
  */
 diff --git a/src/utility/STM32Cube_FW/hw.h b/src/utility/STM32Cube_FW/hw.h
-index 503fa2c..fcf0451 100644
+index 503fa2c..ca4204f 100644
 --- a/src/utility/STM32Cube_FW/hw.h
 +++ b/src/utility/STM32Cube_FW/hw.h
-@@ -26,14 +26,21 @@ extern "C" {
+@@ -26,6 +26,15 @@ extern "C" {
  #endif
  
    /* Includes ------------------------------------------------------------------*/
@@ -553,18 +560,11 @@ index 503fa2c..fcf0451 100644
  
    /******************************************************************************
     * HW IPCC
-    ******************************************************************************/
-   void HW_IPCC_Enable( void );
-   void HW_IPCC_Init( void );
--  void HW_IPCC_Rx_Handler( void );
--  void HW_IPCC_Tx_Handler( void );
- 
-   void HW_IPCC_BLE_Init( void );
-   void HW_IPCC_BLE_SendCmd( void );
-@@ -80,23 +87,6 @@ extern "C" {
+@@ -79,24 +88,6 @@ extern "C" {
+   
    void HW_IPCC_TRACES_Init( void );
    void HW_IPCC_TRACES_EvtNot( void );
- 
+-
 -  void HW_IPCC_MAC_802_15_4_Init( void );
 -  void HW_IPCC_MAC_802_15_4_SendCmd( void );
 -  void HW_IPCC_MAC_802_15_4_SendAck( void );
@@ -586,7 +586,7 @@ index 503fa2c..fcf0451 100644
  }
  #endif
 diff --git a/src/utility/STM32Cube_FW/hw_ipcc.c b/src/utility/STM32Cube_FW/hw_ipcc.c
-index c5a941d..2f4f6cc 100644
+index fd620b8..425a4bc 100644
 --- a/src/utility/STM32Cube_FW/hw_ipcc.c
 +++ b/src/utility/STM32Cube_FW/hw_ipcc.c
 @@ -18,8 +18,9 @@
@@ -690,38 +690,34 @@ index c5a941d..2f4f6cc 100644
    else if (HW_IPCC_TX_PENDING( HW_IPCC_MM_RELEASE_BUFFER_CHANNEL ))
    {
      HW_IPCC_MM_FreeBufHandler();
-@@ -171,9 +131,8 @@ void HW_IPCC_Tx_Handler( void )
+@@ -171,8 +131,6 @@ void HW_IPCC_Tx_Handler( void )
    {
      HW_IPCC_BLE_AclDataEvtHandler();
    }
 -
 -  return;
  }
-+
  /******************************************************************************
   * GENERAL
-  ******************************************************************************/
-@@ -263,8 +222,8 @@ static void HW_IPCC_BLE_AclDataEvtHandler( void )
-   return;
- }
+@@ -266,6 +224,8 @@ static void HW_IPCC_BLE_AclDataEvtHandler( void )
  
--__weak void HW_IPCC_BLE_AclDataAckNot( void ){};
--__weak void HW_IPCC_BLE_RxEvtNot( void ){};
+ __weak void HW_IPCC_BLE_AclDataAckNot( void ){};
+ __weak void HW_IPCC_BLE_RxEvtNot( void ){};
 +__WEAK void HW_IPCC_BLE_AclDataAckNot( void ){};
 +__WEAK void HW_IPCC_BLE_RxEvtNot( void ){};
  
  /******************************************************************************
   * SYSTEM
-@@ -302,56 +261,8 @@ static void HW_IPCC_SYS_EvtHandler( void )
+@@ -303,57 +263,11 @@ static void HW_IPCC_SYS_EvtHandler( void )
    return;
  }
  
 -__weak void HW_IPCC_SYS_CmdEvtNot( void ){};
 -__weak void HW_IPCC_SYS_EvtNot( void ){};
 -
--/******************************************************************************
-- * MAC 802.15.4
-- ******************************************************************************/
+ /******************************************************************************
+  * MAC 802.15.4
+  ******************************************************************************/
 -#ifdef MAC_802_15_4_WB
 -void HW_IPCC_MAC_802_15_4_Init( void )
 -{
@@ -766,12 +762,13 @@ index c5a941d..2f4f6cc 100644
 -__weak void HW_IPCC_MAC_802_15_4_CmdEvtNot( void ){};
 -__weak void HW_IPCC_MAC_802_15_4_EvtNot( void ){};
 -#endif
+-
 +__WEAK void HW_IPCC_SYS_CmdEvtNot( void ){};
 +__WEAK void HW_IPCC_SYS_EvtNot( void ){};
- 
  /******************************************************************************
   * THREAD
-@@ -423,9 +334,9 @@ static void HW_IPCC_THREAD_CliNotEvtHandler( void )
+  ******************************************************************************/
+@@ -424,9 +338,9 @@ static void HW_IPCC_THREAD_CliNotEvtHandler( void )
    return;
  }
  
@@ -784,13 +781,10 @@ index c5a941d..2f4f6cc 100644
  
  #endif /* THREAD_WB */
  
-@@ -547,74 +458,6 @@ void HW_IPCC_LLD_BLE_SendRspAck( void )
- 
- #endif /* LLD_BLE_WB */
- 
--/******************************************************************************
-- * ZIGBEE
-- ******************************************************************************/
+@@ -551,23 +465,6 @@ void HW_IPCC_LLD_BLE_SendRspAck( void )
+ /******************************************************************************
+  * ZIGBEE
+  ******************************************************************************/
 -#ifdef ZIGBEE_WB
 -void HW_IPCC_ZIGBEE_Init( void )
 -{
@@ -808,13 +802,13 @@ index c5a941d..2f4f6cc 100644
 -  return;
 -}
 -
--void HW_IPCC_ZIGBEE_SendM4AckToM0Notify( void )
--{
--  LL_C1_IPCC_ClearFlag_CHx( IPCC, HW_IPCC_ZIGBEE_APPLI_NOTIF_ACK_CHANNEL );
--  LL_C1_IPCC_EnableReceiveChannel( IPCC, HW_IPCC_ZIGBEE_APPLI_NOTIF_ACK_CHANNEL );
--
--  return;
--}
+ void HW_IPCC_ZIGBEE_SendM4AckToM0Notify( void )
+ {
+   LL_C1_IPCC_ClearFlag_CHx( IPCC, HW_IPCC_ZIGBEE_APPLI_NOTIF_ACK_CHANNEL );
+@@ -575,47 +472,6 @@ void HW_IPCC_ZIGBEE_SendM4AckToM0Notify( void )
+ 
+   return;
+ }
 -
 -static void HW_IPCC_ZIGBEE_CmdEvtHandler( void )
 -{
@@ -859,21 +853,21 @@ index c5a941d..2f4f6cc 100644
  /******************************************************************************
   * MEMORY MANAGER
   ******************************************************************************/
-@@ -665,4 +508,5 @@ static void HW_IPCC_TRACES_EvtHandler( void )
-   return;
+@@ -667,3 +523,5 @@ static void HW_IPCC_TRACES_EvtHandler( void )
  }
  
--__weak void HW_IPCC_TRACES_EvtNot( void ){};
+ __weak void HW_IPCC_TRACES_EvtNot( void ){};
 +__WEAK void HW_IPCC_TRACES_EvtNot( void ){};
 +#endif /* STM32WBxx */
 diff --git a/src/utility/STM32Cube_FW/mbox_def.h b/src/utility/STM32Cube_FW/mbox_def.h
-index 06536d3..c898e52 100644
+index 68b71f9..70f8e97 100644
 --- a/src/utility/STM32Cube_FW/mbox_def.h
 +++ b/src/utility/STM32Cube_FW/mbox_def.h
-@@ -105,12 +105,6 @@ extern "C" {
+@@ -105,13 +105,6 @@ extern "C" {
+     uint8_t   *cmdrsp_buffer;
      uint8_t   *m0cmd_buffer;
    } MB_BleLldTable_t;
- 
+-
 -  typedef struct
 -  {
 -    uint8_t   *notifM0toM4_buffer;
@@ -883,7 +877,7 @@ index 06536d3..c898e52 100644
    /**
     * msg
     * [0:7]   = cmd/evt
-@@ -138,13 +132,6 @@ extern "C" {
+@@ -139,13 +132,6 @@ extern "C" {
      uint8_t   *traces_queue;
    } MB_TracesTable_t;
  
@@ -897,7 +891,7 @@ index 06536d3..c898e52 100644
    typedef struct
    {
      MB_DeviceInfoTable_t    *p_device_info_table;
-@@ -153,8 +140,6 @@ extern "C" {
+@@ -154,8 +140,6 @@ extern "C" {
      MB_SysTable_t           *p_sys_table;
      MB_MemManagerTable_t    *p_mem_manager_table;
      MB_TracesTable_t        *p_traces_table;
@@ -906,7 +900,7 @@ index 06536d3..c898e52 100644
      MB_LldTestsTable_t      *p_lld_tests_table;
      MB_BleLldTable_t        *p_ble_lld_table;
  } MB_RefTable_t;
-@@ -198,15 +183,6 @@ typedef struct
+@@ -199,15 +183,6 @@ typedef struct
   *   |                                                 |
   *   |<---HW_IPCC_SYSTEM_EVENT_CHANNEL-----------------|
   *   |                                                 |
@@ -922,7 +916,7 @@ index 06536d3..c898e52 100644
   *   |             (THREAD)                            |
   *   |----HW_IPCC_THREAD_OT_CMD_RSP_CHANNEL----------->|
   *   |                                                 |
-@@ -230,11 +206,6 @@ typedef struct
+@@ -231,11 +206,6 @@ typedef struct
   *   |                                                 |
   *   |<---HW_IPCC_BLE_LLD_M0_CMD_CHANNEL---------------|
   *   |                                                 |
@@ -934,7 +928,7 @@ index 06536d3..c898e52 100644
   *   |             (BUFFER)                            |
   *   |----HW_IPCC_MM_RELEASE_BUFFER_CHANNE------------>|
   *   |                                                 |
-@@ -252,8 +223,6 @@ typedef struct
+@@ -253,8 +223,6 @@ typedef struct
  #define HW_IPCC_BLE_CMD_CHANNEL                         LL_IPCC_CHANNEL_1
  #define HW_IPCC_SYSTEM_CMD_RSP_CHANNEL                  LL_IPCC_CHANNEL_2
  #define HW_IPCC_THREAD_OT_CMD_RSP_CHANNEL               LL_IPCC_CHANNEL_3
@@ -943,7 +937,7 @@ index 06536d3..c898e52 100644
  #define HW_IPCC_MM_RELEASE_BUFFER_CHANNEL               LL_IPCC_CHANNEL_4
  #define HW_IPCC_THREAD_CLI_CMD_CHANNEL                  LL_IPCC_CHANNEL_5
  #define HW_IPCC_LLDTESTS_CLI_CMD_CHANNEL                LL_IPCC_CHANNEL_5
-@@ -265,8 +234,6 @@ typedef struct
+@@ -266,8 +234,6 @@ typedef struct
  #define HW_IPCC_BLE_EVENT_CHANNEL                       LL_IPCC_CHANNEL_1
  #define HW_IPCC_SYSTEM_EVENT_CHANNEL                    LL_IPCC_CHANNEL_2
  #define HW_IPCC_THREAD_NOTIFICATION_ACK_CHANNEL         LL_IPCC_CHANNEL_3
@@ -952,27 +946,21 @@ index 06536d3..c898e52 100644
  #define HW_IPCC_LLDTESTS_M0_CMD_CHANNEL                 LL_IPCC_CHANNEL_3
  #define HW_IPCC_BLE_LLD_M0_CMD_CHANNEL                  LL_IPCC_CHANNEL_3
  #define HW_IPCC_TRACES_CHANNEL                          LL_IPCC_CHANNEL_4
-@@ -274,6 +241,5 @@ typedef struct
- #define HW_IPCC_LLDTESTS_CLI_RSP_CHANNEL                LL_IPCC_CHANNEL_5
- #define HW_IPCC_BLE_LLD_CLI_RSP_CHANNEL                 LL_IPCC_CHANNEL_5
- #define HW_IPCC_BLE_LLD_RSP_CHANNEL                     LL_IPCC_CHANNEL_5
--#define HW_IPCC_ZIGBEE_M0_REQUEST_CHANNEL               LL_IPCC_CHANNEL_5
- #endif /*__MBOX_H */
- 
 diff --git a/src/utility/STM32Cube_FW/shci.c b/src/utility/STM32Cube_FW/shci.c
-index 301db76..bd7bb3a 100644
+index 472a108..586931f 100644
 --- a/src/utility/STM32Cube_FW/shci.c
 +++ b/src/utility/STM32Cube_FW/shci.c
-@@ -16,7 +16,7 @@
+@@ -15,8 +15,7 @@
+  *
   ******************************************************************************
   */
- 
+-
 -
 +#if defined(STM32WBxx)
  /* Includes ------------------------------------------------------------------*/
  #include "stm32_wpan_common.h"
  
-@@ -352,24 +352,6 @@ SHCI_CmdStatus_t SHCI_C2_BLE_LLD_Init( uint8_t param_size, uint8_t * p_param )
+@@ -352,24 +351,6 @@ SHCI_CmdStatus_t SHCI_C2_BLE_LLD_Init( uint8_t param_size, uint8_t * p_param )
    return (SHCI_CmdStatus_t)(((TL_CcEvt_t*)(p_rsp->evtserial.evt.payload))->payload[0]);
  }
  
@@ -997,7 +985,7 @@ index 301db76..bd7bb3a 100644
  SHCI_CmdStatus_t SHCI_C2_DEBUG_Init( SHCI_C2_DEBUG_Init_Cmd_Packet_t *pCmdPacket  )
  {
    /**
-@@ -527,24 +509,6 @@ SHCI_CmdStatus_t SHCI_C2_RADIO_AllowLowPower( SHCI_C2_FLASH_Ip_t Ip,uint8_t  Fla
+@@ -527,24 +508,6 @@ SHCI_CmdStatus_t SHCI_C2_RADIO_AllowLowPower( SHCI_C2_FLASH_Ip_t Ip,uint8_t  Fla
    return (SHCI_CmdStatus_t)(((TL_CcEvt_t*)(p_rsp->evtserial.evt.payload))->payload[0]);
  }
  
@@ -1022,14 +1010,8 @@ index 301db76..bd7bb3a 100644
  SHCI_CmdStatus_t SHCI_C2_Reinit( void )
  {
    /**
-@@ -739,3 +703,5 @@ SHCI_CmdStatus_t SHCI_GetWirelessFwInfo( WirelessFwInfo_t* pWirelessInfo )
- 
-   return (SHCI_Success);
- }
-+#endif /* STM32WBxx */
-+
 diff --git a/src/utility/STM32Cube_FW/shci.h b/src/utility/STM32Cube_FW/shci.h
-index c08f056..9449c22 100644
+index 102089e..2f03114 100644
 --- a/src/utility/STM32Cube_FW/shci.h
 +++ b/src/utility/STM32Cube_FW/shci.h
 @@ -49,7 +49,6 @@ extern "C" {
@@ -1049,7 +1031,7 @@ index c08f056..9449c22 100644
     * section could be written in Flash/NVM
     * StartAddress : Start address of the section that has been modified
     * Size : Size (in bytes) of the section that has been modified
-@@ -214,9 +213,7 @@ extern "C" {
+@@ -216,9 +215,7 @@ extern "C" {
      SHCI_OCF_C2_FLASH_STORE_DATA,
      SHCI_OCF_C2_FLASH_ERASE_DATA,
      SHCI_OCF_C2_RADIO_ALLOW_LOW_POWER,
@@ -1059,7 +1041,34 @@ index c08f056..9449c22 100644
      SHCI_OCF_C2_LLD_TESTS_INIT,
      SHCI_OCF_C2_EXTPA_CONFIG,
      SHCI_OCF_C2_SET_FLASH_ACTIVITY_CONTROL,
-@@ -614,8 +611,6 @@ extern "C" {
+@@ -436,7 +433,7 @@ extern "C" {
+    * PrWriteListSize
+    * NOTE: This parameter is ignored by the CPU2 when the parameter "Options" is set to "LL_only" ( see Options description in that structure )
+    *
+-   * Maximum number of supported \93prepare write request\94
++   * Maximum number of supported \93prepare write request\94
+    *    - Min value: given by the macro DEFAULT_PREP_WRITE_LIST_SIZE
+    *    - Max value: a value higher than the minimum required can be specified, but it is not recommended
+    */
+@@ -502,7 +499,7 @@ extern "C" {
+    * MaxConnEventLength
+    * This parameter determines the maximum duration of a slave connection event. When this duration is reached the slave closes
+    * the current connections event (whatever is the CE_length parameter specified by the master in HCI_CREATE_CONNECTION HCI command),
+-   * expressed in units of 625/256 \B5s (~2.44 \B5s)
++   * expressed in units of 625/256 \B5s (~2.44 \B5s)
+    *    - Min value: 0 (if 0 is specified, the master and slave perform only a single TX-RX exchange per connection event)
+    *    - Max value: 1638400 (4000 ms). A higher value can be specified (max 0xFFFFFFFF) but results in a maximum connection time
+    *      of 4000 ms as specified. In this case the parameter is not applied, and the predicted CE length calculated on slave is not shortened
+@@ -511,7 +508,7 @@ extern "C" {
+ 
+   /**
+    * HsStartupTime
+-   * Startup time of the high speed (16 or 32 MHz) crystal oscillator in units of 625/256 \B5s (~2.44 \B5s).
++   * Startup time of the high speed (16 or 32 MHz) crystal oscillator in units of 625/256 \B5s (~2.44 \B5s).
+    *    - Min value: 0
+    *    - Max value:  820 (~2 ms). A higher value can be specified, but the value that implemented in stack is forced to ~2 ms
+    */
+@@ -648,8 +645,6 @@ extern "C" {
      {
        uint8_t thread_config;
        uint8_t ble_config;
@@ -1068,7 +1077,7 @@ index c08f056..9449c22 100644
      } SHCI_C2_DEBUG_TracesConfig_t;
  
      typedef PACKED_STRUCT
-@@ -674,8 +669,6 @@ extern "C" {
+@@ -713,8 +708,6 @@ extern "C" {
      {
        BLE_ENABLE,
        THREAD_ENABLE,
@@ -1077,7 +1086,7 @@ index c08f056..9449c22 100644
      } SHCI_C2_CONCURRENT_Mode_Param_t;
        /** No response parameters*/
  
-@@ -698,18 +691,13 @@ extern "C" {
+@@ -737,18 +730,13 @@ extern "C" {
      {
        BLE_IP,
        THREAD_IP,
@@ -1096,7 +1105,7 @@ index c08f056..9449c22 100644
  #define SHCI_OPCODE_C2_LLD_TESTS_INIT           (( SHCI_OGF << 10) + SHCI_OCF_C2_LLD_TESTS_INIT)
  
  #define SHCI_OPCODE_C2_BLE_LLD_INIT             (( SHCI_OGF << 10) + SHCI_OCF_C2_BLE_LLD_INIT)
-@@ -817,7 +805,7 @@ extern "C" {
+@@ -856,7 +844,7 @@ extern "C" {
  #define FUS_DEVICE_INFO_TABLE_VALIDITY_KEYWORD    (0xA94656B9)
  
  /*
@@ -1105,8 +1114,8 @@ index c08f056..9449c22 100644
    *   MB_WirelessFwInfoTable_t.This structure contains 4 fields (Version,MemorySize, Stack_info and a reserved part)
    *   each of those coded on 32 bits as shown on the table below:
    *
-@@ -870,9 +858,6 @@ extern "C" {
- #define INFO_STACK_TYPE_BLE_BEACON                  0x04
+@@ -912,9 +900,6 @@ extern "C" {
+ #define INFO_STACK_TYPE_BLE_HCI_EXT_ADV             0x07
  #define INFO_STACK_TYPE_THREAD_FTD                  0x10
  #define INFO_STACK_TYPE_THREAD_MTD                  0x11
 -#define INFO_STACK_TYPE_ZIGBEE_FFD                  0x30
@@ -1115,7 +1124,7 @@ index c08f056..9449c22 100644
  #define INFO_STACK_TYPE_BLE_THREAD_FTD_STATIC       0x50
  #define INFO_STACK_TYPE_BLE_THREAD_FTD_DYAMIC       0x51
  #define INFO_STACK_TYPE_802154_LLD_TESTS            0x60
-@@ -881,12 +866,7 @@ extern "C" {
+@@ -923,12 +908,7 @@ extern "C" {
  #define INFO_STACK_TYPE_BLE_LLD_TESTS               0x63
  #define INFO_STACK_TYPE_BLE_RLV                     0x64
  #define INFO_STACK_TYPE_802154_RLV                  0x65
@@ -1128,7 +1137,7 @@ index c08f056..9449c22 100644
  
  typedef struct {
  /**
-@@ -1060,7 +1040,7 @@ typedef struct {
+@@ -1102,7 +1082,7 @@ typedef struct {
    * @brief Starts the LLD tests CLI
    *
    * @param  param_size : Nb of bytes
@@ -1137,7 +1146,7 @@ index c08f056..9449c22 100644
    * @retval Status
    */
    SHCI_CmdStatus_t SHCI_C2_LLDTESTS_Init( uint8_t param_size, uint8_t * p_param );
-@@ -1070,19 +1050,10 @@ typedef struct {
+@@ -1112,20 +1092,11 @@ typedef struct {
    * @brief Starts the LLD tests BLE
    *
    * @param  param_size : Nb of bytes
@@ -1146,7 +1155,7 @@ index c08f056..9449c22 100644
    * @retval Status
    */
    SHCI_CmdStatus_t SHCI_C2_BLE_LLD_Init( uint8_t param_size, uint8_t * p_param );
--
+   
 -    /**
 -  * SHCI_C2_ZIGBEE_Init
 -  * @brief Starts the Zigbee Stack
@@ -1155,10 +1164,11 @@ index c08f056..9449c22 100644
 -  * @retval Status
 -  */
 -  SHCI_CmdStatus_t SHCI_C2_ZIGBEE_Init( void );
-   
+-
    /**
    * SHCI_C2_DEBUG_Init
-@@ -1158,16 +1129,6 @@ typedef struct {
+   * @brief Starts the Traces
+@@ -1200,16 +1171,6 @@ typedef struct {
    */
    SHCI_CmdStatus_t SHCI_C2_RADIO_AllowLowPower( SHCI_C2_FLASH_Ip_t Ip,uint8_t  FlagRadioLowPowerOn);
  
@@ -1176,13 +1186,14 @@ index c08f056..9449c22 100644
     * SHCI_GetWirelessFwInfo
     * @brief This function read back the informations relative to the wireless binary loaded.
 diff --git a/src/utility/STM32Cube_FW/shci_tl.c b/src/utility/STM32Cube_FW/shci_tl.c
-index 449b8b1..ef403aa 100644
+index ddb3a02..fc398ae 100644
 --- a/src/utility/STM32Cube_FW/shci_tl.c
 +++ b/src/utility/STM32Cube_FW/shci_tl.c
-@@ -16,12 +16,13 @@
+@@ -15,13 +15,13 @@
+  *
   ******************************************************************************
   */
- 
+-
 -
 +#if defined(STM32WBxx)
  /* Includes ------------------------------------------------------------------*/
@@ -1194,7 +1205,7 @@ index 449b8b1..ef403aa 100644
  
  /* Private typedef -----------------------------------------------------------*/
  typedef enum
-@@ -168,6 +169,20 @@ void shci_send( uint16_t cmd_code, uint8_t len_cmd_payload, uint8_t * p_cmd_payl
+@@ -168,6 +168,20 @@ void shci_send( uint16_t cmd_code, uint8_t len_cmd_payload, uint8_t * p_cmd_payl
    return;
  }
  
@@ -1215,47 +1226,35 @@ index 449b8b1..ef403aa 100644
  /* Private functions ---------------------------------------------------------*/
  static void TlInit( TL_CmdPacket_t * p_cmdbuffer )
  {
-@@ -252,3 +267,5 @@ __WEAK void shci_cmd_resp_release(uint32_t flag)
+@@ -251,5 +265,5 @@ __WEAK void shci_cmd_resp_release(uint32_t flag)
+ 
    return;
  }
- 
+-
 +#endif /* STM32WBxx */
-+
+ 
 diff --git a/src/utility/STM32Cube_FW/stm32_wpan_common.h b/src/utility/STM32Cube_FW/stm32_wpan_common.h
-index b47b804..5a2b2a5 100644
+index b47b804..2e4d58e 100644
 --- a/src/utility/STM32Cube_FW/stm32_wpan_common.h
 +++ b/src/utility/STM32Cube_FW/stm32_wpan_common.h
-@@ -25,19 +25,9 @@
- extern "C" {
+@@ -38,6 +38,9 @@ extern "C" {
+  #define __INLINE         inline                                     /*!< inline keyword for GNU Compiler       */
+  #define __STATIC_INLINE  static inline
  #endif
- 
--#if   defined ( __CC_ARM )
-- #define __ASM            __asm                                      /*!< asm keyword for ARM Compiler          */
-- #define __INLINE         __inline                                   /*!< inline keyword for ARM Compiler       */
-- #define __STATIC_INLINE  static __inline
--#elif defined ( __ICCARM__ )
-- #define __ASM            __asm                                      /*!< asm keyword for IAR Compiler          */
-- #define __INLINE         inline                                     /*!< inline keyword for IAR Compiler. Only available in High optimization mode! */
-- #define __STATIC_INLINE  static inline
--#elif defined ( __GNUC__ )
-- #define __ASM            __asm                                      /*!< asm keyword for GNU Compiler          */
-- #define __INLINE         inline                                     /*!< inline keyword for GNU Compiler       */
-- #define __STATIC_INLINE  static inline
--#endif
 +#define __ASM            __asm                                      /*!< asm keyword for GNU Compiler          */
 +#define __INLINE         inline                                     /*!< inline keyword for GNU Compiler       */
 +#define __STATIC_INLINE  static inline
  
  #include <stdint.h>
  #include <string.h>
-@@ -140,29 +130,8 @@ extern "C" {
+@@ -140,29 +143,9 @@ extern "C" {
  /* ----------------------------------- *
   *  Packed usage (compiler dependent)  *
   * ----------------------------------- */
 -#undef PACKED__
  #undef PACKED_STRUCT
 -
--#if defined ( __CC_ARM )
+ #if defined ( __CC_ARM )
 -  #if defined ( __GNUC__ )
 -    /* GNU extension */
 -    #define PACKED__ __attribute__((packed))
@@ -1280,10 +1279,10 @@ index b47b804..5a2b2a5 100644
  #ifdef __cplusplus
  }
 diff --git a/src/utility/STM32Cube_FW/stm_list.c b/src/utility/STM32Cube_FW/stm_list.c
-index 69c8c06..3dea751 100644
+index 4c92864..51a51da 100644
 --- a/src/utility/STM32Cube_FW/stm_list.c
 +++ b/src/utility/STM32Cube_FW/stm_list.c
-@@ -16,13 +16,13 @@
+@@ -16,14 +16,14 @@
    ******************************************************************************
    */
  
@@ -1292,14 +1291,15 @@ index 69c8c06..3dea751 100644
  /******************************************************************************
   * Include Files
   ******************************************************************************/
--#include "utilities_common.h"
+ #include "utilities_common.h"
 -
  #include "stm_list.h"
+-
 +#include "cmsis_gcc.h"
 +#include "stm32_wpan_common.h"
- 
  /******************************************************************************
-  * Function Definitions 
+  * Function Definitions
+  ******************************************************************************/
 @@ -33,10 +33,10 @@ void LST_init_head (tListNode * listHead)
    listHead->prev = listHead;
  }
@@ -1313,12 +1313,11 @@ index 69c8c06..3dea751 100644
  
    primask_bit = __get_PRIMASK();  /**< backup PRIMASK bit */
    __disable_irq();                  /**< Disable all interrupts by setting PRIMASK bit on Cortex*/
-@@ -205,3 +205,4 @@ void LST_get_prev_node (tListNode * ref_node, tListNode ** node)
+@@ -204,3 +204,4 @@ void LST_get_prev_node (tListNode * ref_node, tListNode ** node)
+ 
    __set_PRIMASK(primask_bit);      /**< Restore PRIMASK bit*/
  }
- 
 +#endif /* STM32WBxx */
-\ No newline at end of file
 diff --git a/src/utility/STM32Cube_FW/stm_list.h b/src/utility/STM32Cube_FW/stm_list.h
 index b7c3254..769c211 100644
 --- a/src/utility/STM32Cube_FW/stm_list.h
@@ -1342,10 +1341,10 @@ index b7c3254..769c211 100644
  void LST_insert_head (tListNode * listHead, tListNode * node);
  
 diff --git a/src/utility/STM32Cube_FW/tl.h b/src/utility/STM32Cube_FW/tl.h
-index cb27246..16de7f1 100644
+index 2124d26..678769c 100644
 --- a/src/utility/STM32Cube_FW/tl.h
 +++ b/src/utility/STM32Cube_FW/tl.h
-@@ -198,19 +198,6 @@ typedef struct
+@@ -199,19 +199,6 @@ typedef struct
    uint8_t *p_BleLldM0CmdBuffer;
  } TL_BLE_LLD_Config_t;
  
@@ -1365,7 +1364,7 @@ index cb27246..16de7f1 100644
  /**
   * @brief Contain the BLE HCI Init Configuration
   * @{
-@@ -304,26 +291,6 @@ void TL_MM_EvtDone( TL_EvtPacket_t * hcievt );
+@@ -305,26 +292,6 @@ void TL_MM_EvtDone( TL_EvtPacket_t * hcievt );
  void TL_TRACES_Init( void );
  void TL_TRACES_EvtReceived( TL_EvtPacket_t * hcievt );
  
@@ -1393,7 +1392,7 @@ index cb27246..16de7f1 100644
  } /* extern "C" */
  #endif
 diff --git a/src/utility/STM32Cube_FW/tl_mbox.c b/src/utility/STM32Cube_FW/tl_mbox.c
-index 148bcb1..709f5d2 100644
+index 4112429..4569df4 100644
 --- a/src/utility/STM32Cube_FW/tl_mbox.c
 +++ b/src/utility/STM32Cube_FW/tl_mbox.c
 @@ -16,6 +16,7 @@
@@ -1431,7 +1430,7 @@ index 148bcb1..709f5d2 100644
    HW_IPCC_Init();
  
    return;
-@@ -451,139 +448,6 @@ void TL_BLE_LLD_SendRspAck( void )
+@@ -452,139 +449,6 @@ void TL_BLE_LLD_SendRspAck( void )
  }
  #endif /* BLE_LLD_WB */
  
@@ -1571,12 +1570,11 @@ index 148bcb1..709f5d2 100644
  /******************************************************************************
   * MEMORY MANAGER
   ******************************************************************************/
-@@ -845,3 +709,5 @@ static void OutputDbgTrace(TL_MB_PacketType_t packet_type, uint8_t* buffer)
- 
+@@ -847,3 +711,4 @@ static void OutputDbgTrace(TL_MB_PacketType_t packet_type, uint8_t* buffer)
    return;
  }
-+
+ 
 +#endif /* STM32WBxx */
 -- 
-2.31.1.windows.1
+2.25.1
 

--- a/extras/STM32Cube_FW/0003-Added-support-for-custom-app_conf.h-35.patch
+++ b/extras/STM32Cube_FW/0003-Added-support-for-custom-app_conf.h-35.patch
@@ -1,14 +1,15 @@
-From a771c9e9a12d085fc240a45f68ca5aafb8b42006 Mon Sep 17 00:00:00 2001
-From: Alexandre Bourdiol <alexandre.bourdiol@st.com>
-Date: Mon, 6 Dec 2021 18:59:38 +0100
+From 56bf751554bb993c041a92e774274d69a7a837b7 Mon Sep 17 00:00:00 2001
+From: TLIG Dhaou <dhaou.tlig-ext@st.com>
+Date: Wed, 27 Jul 2022 11:23:10 +0200
 Subject: [PATCH 3/4] Added support for custom app_conf.h (#35)
 
+Signed-off-by: TLIG Dhaou <dhaou.tlig-ext@st.com>
 ---
- src/utility/STM32Cube_FW/app_conf_default.h | 75 ++++++++++++++-------
- 1 file changed, 49 insertions(+), 26 deletions(-)
+ src/utility/STM32Cube_FW/app_conf_default.h | 72 ++++++++++++++-------
+ 1 file changed, 48 insertions(+), 24 deletions(-)
 
 diff --git a/src/utility/STM32Cube_FW/app_conf_default.h b/src/utility/STM32Cube_FW/app_conf_default.h
-index 4f300e0..9f8e085 100644
+index 1d5e06a..492340d 100644
 --- a/src/utility/STM32Cube_FW/app_conf_default.h
 +++ b/src/utility/STM32Cube_FW/app_conf_default.h
 @@ -1,8 +1,8 @@
@@ -24,7 +25,7 @@ index 4f300e0..9f8e085 100644
    *
 @@ -17,11 +17,8 @@
    */
- 
+
  /* Define to prevent recursive inclusion -------------------------------------*/
 -#ifndef APP_CONF_H
 -#define APP_CONF_H
@@ -33,29 +34,29 @@ index 4f300e0..9f8e085 100644
 -#include "ble_bufsize.h"
 +#ifndef APP_CONF_DEFAULT_H
 +#define APP_CONF_DEFAULT_H
- 
+
  /******************************************************************************
   * Application Config
-@@ -44,7 +41,9 @@
- /**
+@@ -48,7 +45,9 @@
   * Define Tx Power
   */
+
 -#define CFG_TX_POWER                      (0x18) /* -0.15dBm */
 +#ifndef CFG_TX_POWER
 +  #define CFG_TX_POWER (0x18) /* -0.15dBm */
 +#endif
- 
+
  /******************************************************************************
   * BLE Stack
-@@ -53,32 +52,41 @@
+@@ -57,32 +56,41 @@
   * Maximum number of simultaneous connections that the device will support.
   * Valid values are from 1 to 8
   */
--#define CFG_BLE_NUM_LINK            2
+-#define CFG_BLE_NUM_LINK            8
 +#ifndef CFG_BLE_NUM_LINK
 +  #define CFG_BLE_NUM_LINK 2
 +#endif
- 
+
  /**
   * Maximum number of Services that can be stored in the GATT database.
 - * Note that the GAP and GATT services are automatically added so this parameter should be 2 plus the number of user services
@@ -65,7 +66,7 @@ index 4f300e0..9f8e085 100644
 +#ifndef CFG_BLE_NUM_GATT_SERVICES
  #define CFG_BLE_NUM_GATT_SERVICES   8
 +#endif
- 
+
  /**
   * Maximum number of Attributes
 - * (i.e. the number of characteristic + the number of characteristic values + the number of descriptors, excluding the services)
@@ -80,16 +81,16 @@ index 4f300e0..9f8e085 100644
 +#ifndef CFG_BLE_NUM_GATT_ATTRIBUTES
 +  #define CFG_BLE_NUM_GATT_ATTRIBUTES 68
 +#endif
- 
+
  /**
   * Maximum supported ATT_MTU size
-  * This parameter is ignored by the CPU2 when CFG_BLE_OPTIONS is set to 1"
+  * This parameter is ignored by the CPU2 when CFG_BLE_OPTIONS has SHCI_C2_BLE_INIT_OPTIONS_LL_ONLY flag set
   */
 -#define CFG_BLE_MAX_ATT_MTU             (156)
 +#ifndef CFG_BLE_MAX_ATT_MTU
 +  #define CFG_BLE_MAX_ATT_MTU (156)
 +#endif
- 
+
  /**
   * Size of the storage area for Attribute values
 - *  This value depends on the number of attributes used by application. In particular the sum of the following quantities (in octets) should be made for each attribute:
@@ -98,27 +99,27 @@ index 4f300e0..9f8e085 100644
   *  - attribute value length
   *  - 5, if UUID is 16 bit; 19, if UUID is 128 bit
   *  - 2, if server configuration descriptor is used
-@@ -87,14 +95,18 @@
+@@ -91,14 +99,18 @@
   *  The total amount of memory needed is the sum of the above quantities for each attribute.
-  * This parameter is ignored by the CPU2 when CFG_BLE_OPTIONS is set to 1"
+  * This parameter is ignored by the CPU2 when CFG_BLE_OPTIONS has SHCI_C2_BLE_INIT_OPTIONS_LL_ONLY flag set
   */
 +#ifndef CFG_BLE_ATT_VALUE_ARRAY_SIZE
  #define CFG_BLE_ATT_VALUE_ARRAY_SIZE    (1344)
 +#endif
- 
+
  /**
   * Prepare Write List size in terms of number of packet
-  * This parameter is ignored by the CPU2 when CFG_BLE_OPTIONS is set to 1"
+  * This parameter is ignored by the CPU2 when CFG_BLE_OPTIONS has SHCI_C2_BLE_INIT_OPTIONS_LL_ONLY flag set
   */
  // #define CFG_BLE_PREPARE_WRITE_LIST_SIZE         BLE_PREP_WRITE_X_ATT(CFG_BLE_MAX_ATT_MTU)
 -#define CFG_BLE_PREPARE_WRITE_LIST_SIZE         (0x3A)
 +#ifndef CFG_BLE_PREPARE_WRITE_LIST_SIZE
 +  #define CFG_BLE_PREPARE_WRITE_LIST_SIZE (0x3A)
 +#endif
- 
+
  /**
   * Number of allocated memory blocks
-@@ -106,12 +118,16 @@
+@@ -110,12 +122,16 @@
  /**
   * Enable or disable the Extended Packet length feature. Valid values are 0 or 1.
   */
@@ -126,7 +127,7 @@ index 4f300e0..9f8e085 100644
 +#ifndef CFG_BLE_DATA_LENGTH_EXTENSION
 +  #define CFG_BLE_DATA_LENGTH_EXTENSION 1
 +#endif
- 
+
  /**
   * Sleep clock accuracy in Slave mode (ppm value)
   */
@@ -134,10 +135,10 @@ index 4f300e0..9f8e085 100644
 +#ifndef CFG_BLE_SLAVE_SCA
 +  #define CFG_BLE_SLAVE_SCA 500
 +#endif
- 
+
  /**
   * Sleep clock accuracy in Master mode
-@@ -124,24 +140,32 @@
+@@ -128,7 +144,9 @@
   * 6 : 21 ppm to 30 ppm
   * 7 : 0 ppm to 20 ppm
   */
@@ -145,17 +146,21 @@ index 4f300e0..9f8e085 100644
 +#ifndef CFG_BLE_MASTER_SCA
 +  #define CFG_BLE_MASTER_SCA 0
 +#endif
- 
+
  /**
-  *  Source for the low speed clock for RF wake-up
-  *  1 : external high speed crystal HSE/32/32
-  *  0 : external low speed crystal ( no calibration )
+  * LsSource
+@@ -136,21 +154,27 @@
+  * - bit 0:   1: Calibration for the RF system wakeup clock source   0: No calibration for the RF system wakeup clock source
+  * - bit 1:   1: STM32W5M Module device                              0: Other devices as STM32WBxx SOC, STM32WB1M module
   */
--#define CFG_BLE_LSE_SOURCE  0
 +#ifndef CFG_BLE_LSE_SOURCE
-+  #define CFG_BLE_LSE_SOURCE 0
+ #if defined(STM32WB5Mxx)
+   #define CFG_BLE_LSE_SOURCE  (SHCI_C2_BLE_INIT_CFG_BLE_LSE_NOCALIB | SHCI_C2_BLE_INIT_CFG_BLE_LSE_MOD5MM_DEV)
+ #else
+   #define CFG_BLE_LSE_SOURCE  (SHCI_C2_BLE_INIT_CFG_BLE_LSE_NOCALIB | SHCI_C2_BLE_INIT_CFG_BLE_LSE_OTHER_DEV)
+ #endif
 +#endif
- 
+
  /**
   * Start up time of the high speed (16 or 32 MHz) crystal oscillator in units of 625/256 us (~2.44 us)
   */
@@ -163,7 +168,7 @@ index 4f300e0..9f8e085 100644
 +#ifndef CFG_BLE_HSE_STARTUP_TIME
 +  #define CFG_BLE_HSE_STARTUP_TIME 0x148
 +#endif
- 
+
  /**
   * Maximum duration of the connection event when the device is in Slave mode in units of 625/256 us (~2.44 us)
   */
@@ -171,16 +176,16 @@ index 4f300e0..9f8e085 100644
 +#ifndef CFG_BLE_MAX_CONN_EVENT_LENGTH
 +  #define CFG_BLE_MAX_CONN_EVENT_LENGTH (0xFFFFFFFF)
 +#endif
- 
+
  /**
   * Viterbi Mode
-@@ -199,5 +223,4 @@
- 
- #define CFG_BLE_RX_MODEL_CONFIG         SHCI_C2_BLE_INIT_RX_MODEL_AGC_RSSI_LEGACY
- 
--
--#endif /*APP_CONF_H */
+@@ -237,5 +261,5 @@
+   */
+
+ #define CFG_BLE_RX_PATH_COMPENS    (0)
+- #endif /*APP_CONF_H */
 +#endif /* APP_CONF_DEFAULT_H */
+
 -- 
-2.31.1.windows.1
+2.25.1
 

--- a/src/utility/STM32Cube_FW/README.md
+++ b/src/utility/STM32Cube_FW/README.md
@@ -1,6 +1,6 @@
 
 ## Source
 
-[STMicroelectronics/STM32CubeWB Release v1.13.3](https://github.com/STMicroelectronics/STM32CubeWB/releases/tag/v1.13.3)
-- Application: [BLE_TransparentMode](https://github.com/STMicroelectronics/STM32CubeWB/tree/v1.13.3/Projects/P-NUCLEO-WB55.Nucleo/Applications/BLE/BLE_TransparentMode)
+[STMicroelectronics/STM32CubeWB Release v1.14.0](https://github.com/STMicroelectronics/STM32CubeWB/releases/tag/v1.14.0)
+- Application: [BLE_TransparentMode](https://github.com/STMicroelectronics/STM32CubeWB/tree/v1.14.0/Projects/P-NUCLEO-WB55.Nucleo/Applications/BLE/BLE_TransparentMode)
 

--- a/src/utility/STM32Cube_FW/app_conf_default.h
+++ b/src/utility/STM32Cube_FW/app_conf_default.h
@@ -24,6 +24,9 @@
  * Application Config
  ******************************************************************************/
 
+/**
+ * Define Keypress Notification Support
+ */
 /**< generic parameters ******************************************************/
 /* HCI related defines */
 
@@ -41,6 +44,7 @@
 /**
  * Define Tx Power
  */
+
 #ifndef CFG_TX_POWER
   #define CFG_TX_POWER (0x18) /* -0.15dBm */
 #endif
@@ -77,7 +81,7 @@
 
 /**
  * Maximum supported ATT_MTU size
- * This parameter is ignored by the CPU2 when CFG_BLE_OPTIONS is set to 1"
+ * This parameter is ignored by the CPU2 when CFG_BLE_OPTIONS has SHCI_C2_BLE_INIT_OPTIONS_LL_ONLY flag set
  */
 #ifndef CFG_BLE_MAX_ATT_MTU
   #define CFG_BLE_MAX_ATT_MTU (156)
@@ -93,7 +97,7 @@
  *  - 2*DTM_NUM_LINK, if client configuration descriptor is used
  *  - 2, if extended properties is used
  *  The total amount of memory needed is the sum of the above quantities for each attribute.
- * This parameter is ignored by the CPU2 when CFG_BLE_OPTIONS is set to 1"
+ * This parameter is ignored by the CPU2 when CFG_BLE_OPTIONS has SHCI_C2_BLE_INIT_OPTIONS_LL_ONLY flag set
  */
 #ifndef CFG_BLE_ATT_VALUE_ARRAY_SIZE
 #define CFG_BLE_ATT_VALUE_ARRAY_SIZE    (1344)
@@ -101,7 +105,7 @@
 
 /**
  * Prepare Write List size in terms of number of packet
- * This parameter is ignored by the CPU2 when CFG_BLE_OPTIONS is set to 1"
+ * This parameter is ignored by the CPU2 when CFG_BLE_OPTIONS has SHCI_C2_BLE_INIT_OPTIONS_LL_ONLY flag set
  */
 // #define CFG_BLE_PREPARE_WRITE_LIST_SIZE         BLE_PREP_WRITE_X_ATT(CFG_BLE_MAX_ATT_MTU)
 #ifndef CFG_BLE_PREPARE_WRITE_LIST_SIZE
@@ -110,7 +114,7 @@
 
 /**
  * Number of allocated memory blocks
- * This parameter is overwritten by the CPU2 with an hardcoded optimal value when the parameter when CFG_BLE_OPTIONS is set to 1
+ * This parameter is overwritten by the CPU2 with an hardcoded optimal value when the parameter CFG_BLE_OPTIONS has SHCI_C2_BLE_INIT_OPTIONS_LL_ONLY flag set
  */
 // #define CFG_BLE_MBLOCK_COUNT            (BLE_MBLOCKS_CALC(CFG_BLE_PREPARE_WRITE_LIST_SIZE, CFG_BLE_MAX_ATT_MTU, CFG_BLE_NUM_LINK))
 #define CFG_BLE_MBLOCK_COUNT              (0x79)
@@ -145,12 +149,17 @@
 #endif
 
 /**
- *  Source for the low speed clock for RF wake-up
- *  1 : external high speed crystal HSE/32/32
- *  0 : external low speed crystal ( no calibration )
+ * LsSource
+ * Some information for Low speed clock mapped in bits field
+ * - bit 0:   1: Calibration for the RF system wakeup clock source   0: No calibration for the RF system wakeup clock source
+ * - bit 1:   1: STM32W5M Module device                              0: Other devices as STM32WBxx SOC, STM32WB1M module
  */
 #ifndef CFG_BLE_LSE_SOURCE
-  #define CFG_BLE_LSE_SOURCE 0
+#if defined(STM32WB5Mxx)
+  #define CFG_BLE_LSE_SOURCE  (SHCI_C2_BLE_INIT_CFG_BLE_LSE_NOCALIB | SHCI_C2_BLE_INIT_CFG_BLE_LSE_MOD5MM_DEV)
+#else
+  #define CFG_BLE_LSE_SOURCE  (SHCI_C2_BLE_INIT_CFG_BLE_LSE_NOCALIB | SHCI_C2_BLE_INIT_CFG_BLE_LSE_OTHER_DEV)
+#endif
 #endif
 
 /**
@@ -195,8 +204,8 @@
  *          0: with service change desc.
  * (bit 2): 1: device name Read-Only
  *          0: device name R/W
- * (bit 3): 1: extended advertizing supported       [NOT SUPPORTED]
- *          0: extended advertizing not supported   [NOT SUPPORTED]
+ * (bit 3): 1: extended advertizing supported
+ *          0: extended advertizing not supported
  * (bit 4): 1: CS Algo #2 supported
  *          0: CS Algo #2 not supported
  * (bit 7): 1: LE Power Class 1
@@ -207,9 +216,9 @@
 
 #define CFG_BLE_MAX_COC_INITIATOR_NBR   (32)
 
-#define CFG_BLE_MIN_TX_POWER            (0)
+#define CFG_BLE_MIN_TX_POWER            (-40)
 
-#define CFG_BLE_MAX_TX_POWER            (0)
+#define CFG_BLE_MAX_TX_POWER            (6)
 
 /**
  * BLE Rx model configuration flags to be configured with:
@@ -221,6 +230,36 @@
  * other bits: reserved (shall be set to 0)
  */
 
-#define CFG_BLE_RX_MODEL_CONFIG         SHCI_C2_BLE_INIT_RX_MODEL_AGC_RSSI_LEGACY
+#define CFG_BLE_RX_MODEL_CONFIG         (SHCI_C2_BLE_INIT_RX_MODEL_AGC_RSSI_LEGACY)
 
+/* Maximum number of advertising sets.
+ * Range: 1 .. 8 with limitation:
+ * This parameter is linked to CFG_BLE_MAX_ADV_DATA_LEN such as both compliant with allocated Total memory computed with BLE_EXT_ADV_BUFFER_SIZE based
+ * on Max Extended advertising configuration supported.
+ * This parameter is considered by the CPU2 when CFG_BLE_OPTIONS has SHCI_C2_BLE_INIT_OPTIONS_EXT_ADV flag set
+ */
+
+#define CFG_BLE_MAX_ADV_SET_NBR     (8)
+
+ /* Maximum advertising data length (in bytes)
+ * Range: 31 .. 1650 with limitation:
+ * This parameter is linked to CFG_BLE_MAX_ADV_SET_NBR such as both compliant with allocated Total memory computed with BLE_EXT_ADV_BUFFER_SIZE based
+ * on Max Extended advertising configuration supported.
+ * This parameter is considered by the CPU2 when CFG_BLE_OPTIONS has SHCI_C2_BLE_INIT_OPTIONS_EXT_ADV flag set
+ */
+
+#define CFG_BLE_MAX_ADV_DATA_LEN    (207)
+
+ /* RF TX Path Compensation Value (16-bit signed integer). Units: 0.1 dB.
+  * Range: -1280 .. 1280
+  */
+
+#define CFG_BLE_TX_PATH_COMPENS    (0)
+
+ /* RF RX Path Compensation Value (16-bit signed integer). Units: 0.1 dB.
+  * Range: -1280 .. 1280
+  */
+
+#define CFG_BLE_RX_PATH_COMPENS    (0)
 #endif /* APP_CONF_DEFAULT_H */
+

--- a/src/utility/STM32Cube_FW/ble_bufsize.h
+++ b/src/utility/STM32Cube_FW/ble_bufsize.h
@@ -84,28 +84,33 @@
 
 /*
  * BLE_FIXED_BUFFER_SIZE_BYTES:
- * A part of the RAM, is dynamically allocated by initializing all the pointers 
+ * A part of the RAM, is dinamically allocated by initilizing all the pointers
+ * A part of the RAM, is dynamically allocated by initializing all the pointers
  * defined in a global context variable "mem_alloc_ctx_p".
  * This initialization is made in the Dynamic_allocator functions, which 
+ * assing a portion of RAM given by the external application to the above
  * assign a portion of RAM given by the external application to the above
  * mentioned "global pointers".
  *
  * The size of this Dynamic RAM is made of 2 main components: 
  * - a part that is parameters-dependent (num of links, GATT buffers, ...),
+ *   and which value is explicited by the following macro;
  *   and which value is defined by the following macro;
  * - a part, that may be considered "fixed", i.e. independent from the above
  *   mentioned parameters.
 */
 #if (BEACON_ONLY != 0)
 #define BLE_FIXED_BUFFER_SIZE_BYTES  4076   /* Beacon only */
+#elif (LL_ONLY_BASIC != 0)
+#define BLE_FIXED_BUFFER_SIZE_BYTES  5692   /* LL only Basic*/
 #elif (LL_ONLY != 0)
-#define BLE_FIXED_BUFFER_SIZE_BYTES  5936   /* LL only */
+#define BLE_FIXED_BUFFER_SIZE_BYTES  5940   /* LL only Full */
 #elif (SLAVE_ONLY != 0)
 #define BLE_FIXED_BUFFER_SIZE_BYTES  6204   /* Peripheral only */
 #elif (BASIC_FEATURES != 0)
 #define BLE_FIXED_BUFFER_SIZE_BYTES  6532   /* Basic Features */
 #else
-#define BLE_FIXED_BUFFER_SIZE_BYTES  7052   /* Full stack */
+#define BLE_FIXED_BUFFER_SIZE_BYTES  7056   /* Full stack */
 #endif
 
 /*
@@ -113,8 +118,10 @@
  */
 #if (BEACON_ONLY != 0)
 #define BLE_PER_LINK_SIZE_BYTES       128   /* Beacon only */
+#elif (LL_ONLY_BASIC != 0)
+#define BLE_PER_LINK_SIZE_BYTES       260   /* LL only Basic */
 #elif (LL_ONLY != 0)
-#define BLE_PER_LINK_SIZE_BYTES       260   /* LL only */
+#define BLE_PER_LINK_SIZE_BYTES       260   /* LL only Full */
 #elif (SLAVE_ONLY != 0)
 #define BLE_PER_LINK_SIZE_BYTES       392   /* Peripheral only */
 #elif (BASIC_FEATURES != 0)

--- a/src/utility/STM32Cube_FW/hw.h
+++ b/src/utility/STM32Cube_FW/hw.h
@@ -41,6 +41,8 @@ extern "C" {
    ******************************************************************************/
   void HW_IPCC_Enable( void );
   void HW_IPCC_Init( void );
+  void HW_IPCC_Rx_Handler( void );
+  void HW_IPCC_Tx_Handler( void );
 
   void HW_IPCC_BLE_Init( void );
   void HW_IPCC_BLE_SendCmd( void );
@@ -86,7 +88,6 @@ extern "C" {
   
   void HW_IPCC_TRACES_Init( void );
   void HW_IPCC_TRACES_EvtNot( void );
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/utility/STM32Cube_FW/mbox_def.h
+++ b/src/utility/STM32Cube_FW/mbox_def.h
@@ -91,6 +91,7 @@ extern "C" {
     uint8_t   *notack_buffer;
     uint8_t   *clicmdrsp_buffer;
     uint8_t   *otcmdrsp_buffer;
+    uint8_t   *clinot_buffer;
   } MB_ThreadTable_t;
 
   typedef struct
@@ -104,7 +105,6 @@ extern "C" {
     uint8_t   *cmdrsp_buffer;
     uint8_t   *m0cmd_buffer;
   } MB_BleLldTable_t;
-
   /**
    * msg
    * [0:7]   = cmd/evt
@@ -241,5 +241,6 @@ typedef struct
 #define HW_IPCC_LLDTESTS_CLI_RSP_CHANNEL                LL_IPCC_CHANNEL_5
 #define HW_IPCC_BLE_LLD_CLI_RSP_CHANNEL                 LL_IPCC_CHANNEL_5
 #define HW_IPCC_BLE_LLD_RSP_CHANNEL                     LL_IPCC_CHANNEL_5
+#define HW_IPCC_ZIGBEE_M0_REQUEST_CHANNEL               LL_IPCC_CHANNEL_5
 #endif /*__MBOX_H */
 

--- a/src/utility/STM32Cube_FW/shci.c
+++ b/src/utility/STM32Cube_FW/shci.c
@@ -15,7 +15,6 @@
  *
  ******************************************************************************
  */
-
 #if defined(STM32WBxx)
 /* Includes ------------------------------------------------------------------*/
 #include "stm32_wpan_common.h"
@@ -703,5 +702,4 @@ SHCI_CmdStatus_t SHCI_GetWirelessFwInfo( WirelessFwInfo_t* pWirelessInfo )
 
   return (SHCI_Success);
 }
-#endif /* STM32WBxx */
 

--- a/src/utility/STM32Cube_FW/shci_tl.c
+++ b/src/utility/STM32Cube_FW/shci_tl.c
@@ -15,12 +15,9 @@
  *
  ******************************************************************************
  */
-
 #if defined(STM32WBxx)
 /* Includes ------------------------------------------------------------------*/
 #include "stm32_wpan_common.h"
-
-#include <Arduino.h>
 
 #include "stm_list.h"
 #include "shci_tl.h"
@@ -252,12 +249,11 @@ static void TlUserEvtReceived(TL_EvtPacket_t *shcievt)
 /* Weak implementation ----------------------------------------------------------------*/
 __WEAK void shci_cmd_resp_wait(uint32_t timeout)
 {
+  (void)timeout;
+
   CmdRspStatusFlag = SHCI_TL_CMD_RESP_WAIT;
-  for (unsigned long start = millis(); (millis() - start) < timeout;) {
-    if (CmdRspStatusFlag == SHCI_TL_CMD_RESP_RELEASE) {
-      break;
-    }
-  }
+  while(CmdRspStatusFlag != SHCI_TL_CMD_RESP_RELEASE);
+
   return;
 }
 
@@ -269,6 +265,5 @@ __WEAK void shci_cmd_resp_release(uint32_t flag)
 
   return;
 }
-
 #endif /* STM32WBxx */
 

--- a/src/utility/STM32Cube_FW/stm32_wpan_common.h
+++ b/src/utility/STM32Cube_FW/stm32_wpan_common.h
@@ -25,6 +25,19 @@
 extern "C" {
 #endif
 
+#if   defined ( __CC_ARM )
+ #define __ASM            __asm                                      /*!< asm keyword for ARM Compiler          */
+ #define __INLINE         __inline                                   /*!< inline keyword for ARM Compiler       */
+ #define __STATIC_INLINE  static __inline
+#elif defined ( __ICCARM__ )
+ #define __ASM            __asm                                      /*!< asm keyword for IAR Compiler          */
+ #define __INLINE         inline                                     /*!< inline keyword for IAR Compiler. Only available in High optimization mode! */
+ #define __STATIC_INLINE  static inline
+#elif defined ( __GNUC__ )
+ #define __ASM            __asm                                      /*!< asm keyword for GNU Compiler          */
+ #define __INLINE         inline                                     /*!< inline keyword for GNU Compiler       */
+ #define __STATIC_INLINE  static inline
+#endif
 #define __ASM            __asm                                      /*!< asm keyword for GNU Compiler          */
 #define __INLINE         inline                                     /*!< inline keyword for GNU Compiler       */
 #define __STATIC_INLINE  static inline
@@ -131,6 +144,7 @@ extern "C" {
  *  Packed usage (compiler dependent)  *
  * ----------------------------------- */
 #undef PACKED_STRUCT
+#if defined ( __CC_ARM )
 #define PACKED_STRUCT struct __packed
 
 #ifdef __cplusplus

--- a/src/utility/STM32Cube_FW/stm_list.c
+++ b/src/utility/STM32Cube_FW/stm_list.c
@@ -20,12 +20,12 @@
 /******************************************************************************
  * Include Files
  ******************************************************************************/
+#include "utilities_common.h"
 #include "stm_list.h"
 #include "cmsis_gcc.h"
 #include "stm32_wpan_common.h"
-
 /******************************************************************************
- * Function Definitions 
+ * Function Definitions
  ******************************************************************************/
 void LST_init_head (tListNode * listHead)
 {
@@ -204,5 +204,4 @@ void LST_get_prev_node (tListNode * ref_node, tListNode ** node)
 
   __set_PRIMASK(primask_bit);      /**< Restore PRIMASK bit*/
 }
-
-#endif /* STM32WBxx */
+#endif /* STM32WBxx */

--- a/src/utility/STM32Cube_FW/tl.h
+++ b/src/utility/STM32Cube_FW/tl.h
@@ -184,6 +184,7 @@ typedef struct
   uint8_t *p_ThreadOtCmdRspBuffer;
   uint8_t *p_ThreadCliRspBuffer;
   uint8_t *p_ThreadNotAckBuffer;
+  uint8_t *p_ThreadCliNotBuffer;
 } TL_TH_Config_t;
 
 typedef struct

--- a/src/utility/STM32Cube_FW/tl_mbox.c
+++ b/src/utility/STM32Cube_FW/tl_mbox.c
@@ -24,6 +24,7 @@
 #include "stm_list.h"
 #include "tl.h"
 #include "mbox_def.h"
+#include "tl_dbg_conf.h"
 
 /* Private typedef -----------------------------------------------------------*/
 typedef enum
@@ -256,6 +257,7 @@ void TL_THREAD_Init( TL_TH_Config_t *p_Config )
   p_thread_table->clicmdrsp_buffer = p_Config->p_ThreadCliRspBuffer;
   p_thread_table->otcmdrsp_buffer = p_Config->p_ThreadOtCmdRspBuffer;
   p_thread_table->notack_buffer = p_Config->p_ThreadNotAckBuffer;
+  p_thread_table->clinot_buffer = p_Config->p_ThreadCliNotBuffer;
 
   HW_IPCC_THREAD_Init();
 
@@ -314,7 +316,7 @@ void HW_IPCC_THREAD_EvtNot( void )
 
 void HW_IPCC_THREAD_CliEvtNot( void )
 {
-  TL_THREAD_CliNotReceived( (TL_EvtPacket_t*)(TL_RefTable.p_thread_table->clicmdrsp_buffer) );
+  TL_THREAD_CliNotReceived( (TL_EvtPacket_t*)(TL_RefTable.p_thread_table->clinot_buffer) );
 
   return;
 }
@@ -531,9 +533,180 @@ __WEAK void TL_TRACES_EvtReceived( TL_EvtPacket_t * hcievt )
  ******************************************************************************/
 static void OutputDbgTrace(TL_MB_PacketType_t packet_type, uint8_t* buffer)
 {
-  /* Function stubbed */
-  UNUSED(packet_type);
-  UNUSED(buffer);
+  TL_EvtPacket_t *p_evt_packet;
+  TL_CmdPacket_t *p_cmd_packet;
+
+  switch(packet_type)
+  {
+    case TL_MB_MM_RELEASE_BUFFER:
+      p_evt_packet = (TL_EvtPacket_t*)buffer;
+      switch(p_evt_packet->evtserial.evt.evtcode)
+      {
+        case TL_BLEEVT_CS_OPCODE:
+          TL_MM_DBG_MSG("mm evt released: 0x%02X", p_evt_packet->evtserial.evt.evtcode);
+          TL_MM_DBG_MSG(" cmd opcode: 0x%04X", ((TL_CsEvt_t*)(p_evt_packet->evtserial.evt.payload))->cmdcode);
+          TL_MM_DBG_MSG(" buffer addr: 0x%08X", p_evt_packet);
+          break;
+
+        case TL_BLEEVT_CC_OPCODE:
+          TL_MM_DBG_MSG("mm evt released: 0x%02X", p_evt_packet->evtserial.evt.evtcode);
+          TL_MM_DBG_MSG(" cmd opcode: 0x%04X", ((TL_CcEvt_t*)(p_evt_packet->evtserial.evt.payload))->cmdcode);
+          TL_MM_DBG_MSG(" buffer addr: 0x%08X", p_evt_packet);
+          break;
+
+        case TL_BLEEVT_VS_OPCODE:
+          TL_MM_DBG_MSG("mm evt released: 0x%02X", p_evt_packet->evtserial.evt.evtcode);
+          TL_MM_DBG_MSG(" subevtcode: 0x%04X", ((TL_AsynchEvt_t*)(p_evt_packet->evtserial.evt.payload))->subevtcode);
+          TL_MM_DBG_MSG(" buffer addr: 0x%08X", p_evt_packet);
+          break;
+
+        default:
+          TL_MM_DBG_MSG("mm evt released: 0x%02X", p_evt_packet->evtserial.evt.evtcode);
+          TL_MM_DBG_MSG(" buffer addr: 0x%08X", p_evt_packet);
+          break;
+      }
+
+      TL_MM_DBG_MSG("\r\n");
+      break;
+
+    case TL_MB_BLE_CMD:
+      p_cmd_packet = (TL_CmdPacket_t*)buffer;
+      TL_HCI_CMD_DBG_MSG("ble cmd: 0x%04X", p_cmd_packet->cmdserial.cmd.cmdcode);
+      if(p_cmd_packet->cmdserial.cmd.plen != 0)
+      {
+        TL_HCI_CMD_DBG_MSG(" payload:");
+        TL_HCI_CMD_DBG_BUF(p_cmd_packet->cmdserial.cmd.payload, p_cmd_packet->cmdserial.cmd.plen, "");
+      }
+      TL_HCI_CMD_DBG_MSG("\r\n");
+
+      TL_HCI_CMD_DBG_RAW(&p_cmd_packet->cmdserial, p_cmd_packet->cmdserial.cmd.plen+TL_CMD_HDR_SIZE);
+      break;
+
+    case TL_MB_BLE_CMD_RSP:
+      p_evt_packet = (TL_EvtPacket_t*)buffer;
+      switch(p_evt_packet->evtserial.evt.evtcode)
+      {
+        case TL_BLEEVT_CS_OPCODE:
+          TL_HCI_CMD_DBG_MSG("ble rsp: 0x%02X", p_evt_packet->evtserial.evt.evtcode);
+          TL_HCI_CMD_DBG_MSG(" cmd opcode: 0x%04X", ((TL_CsEvt_t*)(p_evt_packet->evtserial.evt.payload))->cmdcode);
+          TL_HCI_CMD_DBG_MSG(" numhci: 0x%02X", ((TL_CsEvt_t*)(p_evt_packet->evtserial.evt.payload))->numcmd);
+          TL_HCI_CMD_DBG_MSG(" status: 0x%02X", ((TL_CsEvt_t*)(p_evt_packet->evtserial.evt.payload))->status);
+          break;
+
+        case TL_BLEEVT_CC_OPCODE:
+          TL_HCI_CMD_DBG_MSG("ble rsp: 0x%02X", p_evt_packet->evtserial.evt.evtcode);
+          TL_HCI_CMD_DBG_MSG(" cmd opcode: 0x%04X", ((TL_CcEvt_t*)(p_evt_packet->evtserial.evt.payload))->cmdcode);
+          TL_HCI_CMD_DBG_MSG(" numhci: 0x%02X", ((TL_CcEvt_t*)(p_evt_packet->evtserial.evt.payload))->numcmd);
+          TL_HCI_CMD_DBG_MSG(" status: 0x%02X", ((TL_CcEvt_t*)(p_evt_packet->evtserial.evt.payload))->payload[0]);
+          if((p_evt_packet->evtserial.evt.plen-4) != 0)
+          {
+            TL_HCI_CMD_DBG_MSG(" payload:");
+            TL_HCI_CMD_DBG_BUF(&((TL_CcEvt_t*)(p_evt_packet->evtserial.evt.payload))->payload[1], p_evt_packet->evtserial.evt.plen-4, "");
+          }
+          break;
+
+        default:
+          TL_HCI_CMD_DBG_MSG("unknown ble rsp received: %02X", p_evt_packet->evtserial.evt.evtcode);
+          break;
+      }
+
+      TL_HCI_CMD_DBG_MSG("\r\n");
+
+      TL_HCI_CMD_DBG_RAW(&p_evt_packet->evtserial, p_evt_packet->evtserial.evt.plen+TL_EVT_HDR_SIZE);
+      break;
+
+    case TL_MB_BLE_ASYNCH_EVT:
+      p_evt_packet = (TL_EvtPacket_t*)buffer;
+      if(p_evt_packet->evtserial.evt.evtcode != TL_BLEEVT_VS_OPCODE)
+      {
+        TL_HCI_EVT_DBG_MSG("ble evt: 0x%02X", p_evt_packet->evtserial.evt.evtcode);
+        if((p_evt_packet->evtserial.evt.plen) != 0)
+        {
+          TL_HCI_EVT_DBG_MSG(" payload:");
+          TL_HCI_EVT_DBG_BUF(p_evt_packet->evtserial.evt.payload, p_evt_packet->evtserial.evt.plen, "");
+        }
+      }
+      else
+      {
+        TL_HCI_EVT_DBG_MSG("ble evt: 0x%02X", p_evt_packet->evtserial.evt.evtcode);
+        TL_HCI_EVT_DBG_MSG(" subevtcode: 0x%04X", ((TL_AsynchEvt_t*)(p_evt_packet->evtserial.evt.payload))->subevtcode);
+        if((p_evt_packet->evtserial.evt.plen-2) != 0)
+        {
+          TL_HCI_EVT_DBG_MSG(" payload:");
+          TL_HCI_EVT_DBG_BUF(((TL_AsynchEvt_t*)(p_evt_packet->evtserial.evt.payload))->payload, p_evt_packet->evtserial.evt.plen-2, "");
+        }
+      }
+
+      TL_HCI_EVT_DBG_MSG("\r\n");
+
+      TL_HCI_EVT_DBG_RAW(&p_evt_packet->evtserial, p_evt_packet->evtserial.evt.plen+TL_EVT_HDR_SIZE);
+      break;
+
+    case TL_MB_SYS_CMD:
+      p_cmd_packet = (TL_CmdPacket_t*)buffer;
+
+      TL_SHCI_CMD_DBG_MSG("sys cmd: 0x%04X", p_cmd_packet->cmdserial.cmd.cmdcode);
+
+      if(p_cmd_packet->cmdserial.cmd.plen != 0)
+      {
+        TL_SHCI_CMD_DBG_MSG(" payload:");
+        TL_SHCI_CMD_DBG_BUF(p_cmd_packet->cmdserial.cmd.payload, p_cmd_packet->cmdserial.cmd.plen, "");
+      }
+      TL_SHCI_CMD_DBG_MSG("\r\n");
+
+      TL_SHCI_CMD_DBG_RAW(&p_cmd_packet->cmdserial, p_cmd_packet->cmdserial.cmd.plen+TL_CMD_HDR_SIZE);
+      break;
+
+    case TL_MB_SYS_CMD_RSP:
+      p_evt_packet = (TL_EvtPacket_t*)buffer;
+      switch(p_evt_packet->evtserial.evt.evtcode)
+      {
+        case TL_BLEEVT_CC_OPCODE:
+          TL_SHCI_CMD_DBG_MSG("sys rsp: 0x%02X", p_evt_packet->evtserial.evt.evtcode);
+          TL_SHCI_CMD_DBG_MSG(" cmd opcode: 0x%02X", ((TL_CcEvt_t*)(p_evt_packet->evtserial.evt.payload))->cmdcode);
+          TL_SHCI_CMD_DBG_MSG(" status: 0x%02X", ((TL_CcEvt_t*)(p_evt_packet->evtserial.evt.payload))->payload[0]);
+          if((p_evt_packet->evtserial.evt.plen-4) != 0)
+          {
+            TL_SHCI_CMD_DBG_MSG(" payload:");
+            TL_SHCI_CMD_DBG_BUF(&((TL_CcEvt_t*)(p_evt_packet->evtserial.evt.payload))->payload[1], p_evt_packet->evtserial.evt.plen-4, "");
+          }
+          break;
+
+        default:
+          TL_SHCI_CMD_DBG_MSG("unknown sys rsp received: %02X", p_evt_packet->evtserial.evt.evtcode);
+          break;
+      }
+
+      TL_SHCI_CMD_DBG_MSG("\r\n");
+
+      TL_SHCI_CMD_DBG_RAW(&p_evt_packet->evtserial, p_evt_packet->evtserial.evt.plen+TL_EVT_HDR_SIZE);
+      break;
+
+    case  TL_MB_SYS_ASYNCH_EVT:
+      p_evt_packet = (TL_EvtPacket_t*)buffer;
+      if(p_evt_packet->evtserial.evt.evtcode != TL_BLEEVT_VS_OPCODE)
+      {
+        TL_SHCI_EVT_DBG_MSG("unknown sys evt received: %02X", p_evt_packet->evtserial.evt.evtcode);
+      }
+      else
+      {
+        TL_SHCI_EVT_DBG_MSG("sys evt: 0x%02X", p_evt_packet->evtserial.evt.evtcode);
+        TL_SHCI_EVT_DBG_MSG(" subevtcode: 0x%04X", ((TL_AsynchEvt_t*)(p_evt_packet->evtserial.evt.payload))->subevtcode);
+        if((p_evt_packet->evtserial.evt.plen-2) != 0)
+        {
+          TL_SHCI_EVT_DBG_MSG(" payload:");
+          TL_SHCI_EVT_DBG_BUF(((TL_AsynchEvt_t*)(p_evt_packet->evtserial.evt.payload))->payload, p_evt_packet->evtserial.evt.plen-2, "");
+        }
+      }
+
+      TL_SHCI_EVT_DBG_MSG("\r\n");
+
+      TL_SHCI_EVT_DBG_RAW(&p_evt_packet->evtserial, p_evt_packet->evtserial.evt.plen+TL_EVT_HDR_SIZE);
+      break;
+
+    default:
+      break;
+  }
 
   return;
 }


### PR DESCRIPTION
In this commit we have regenerated 2 patch files,
which are respectively:
- 0001-chore-clean-up-and-adapt-STM32Cube_FW-sources-for-ST.patch
- 0003-Added-support-for-custom-app_conf.h-35.patch


Signed-off-by: TLIG Dhaou <dhaou.tlig-ext@st.com>