### PR TITLE
Add API to get random address

### DIFF
--- a/src/local/BLELocalDevice.cpp
+++ b/src/local/BLELocalDevice.cpp
@@ -60,6 +60,15 @@ int BLELocalDevice::begin()
    * Force both MSB bits to b00 in order to define Static Random Address
    */
   randomNumber[5] |= 0xC0;
+
+  // Copy the random address in private variable as it will be sent to the BLE chip
+  randomAddress [0] = randomNumber[0];
+  randomAddress [1] = randomNumber[1];
+  randomAddress [2] = randomNumber[2];
+  randomAddress [3] = randomNumber[3];
+  randomAddress [4] = randomNumber[4];
+  randomAddress [5] = randomNumber[5];
+
   if (HCI.leSetRandomAddress((uint8_t*)randomNumber) != 0) {
     end();
     return 0;
@@ -103,6 +112,16 @@ void BLELocalDevice::end()
   GATT.end();
 
   HCI.end();
+}
+
+void BLELocalDevice::getRandomAddress(uint8_t buff[6])
+{
+  buff [0] = randomAddress[0];
+  buff [1] = randomAddress[1];
+  buff [2] = randomAddress[2];
+  buff [3] = randomAddress[3];
+  buff [4] = randomAddress[4];
+  buff [5] = randomAddress[5];
 }
 
 void BLELocalDevice::poll()

--- a/src/local/BLELocalDevice.h
+++ b/src/local/BLELocalDevice.h
@@ -84,6 +84,8 @@ public:
 
   virtual void setTimeout(unsigned long timeout);
 
+  virtual void getRandomAddress(uint8_t buff[6]);
+
   virtual void debug(Stream& stream);
   virtual void noDebug();
   
@@ -92,6 +94,7 @@ protected:
   virtual BLEAdvertisingData& getScanResponseData();
 
 private:
+  uint8_t randomAddress[6];
   HCITransportInterface *_HCITransport;
   BLEAdvertisingData _advertisingData;
   BLEAdvertisingData _scanResponseData;


### PR DESCRIPTION
I would like to add new functionality for compatibility for ST BLE Sensor applications, such as Flight1, that require the random address.