### PR TITLE
fix: TL_Evt_t payload size for reset

### DIFF
--- a/extras/STM32Cube_FW/0001-chore-adapt-STM32Cube_FW-sources.patch
+++ b/extras/STM32Cube_FW/0001-chore-adapt-STM32Cube_FW-sources.patch
@@ -1,7 +1,7 @@
-From fd17a2302d60208768610cb4723eb403c52ff2b1 Mon Sep 17 00:00:00 2001
+From 542e007fa5a1b53664d2efb5f01d67767123a357 Mon Sep 17 00:00:00 2001
 From: Frederic Pillon <frederic.pillon@st.com>
 Date: Thu, 13 Jul 2023 17:08:05 +0200
-Subject: [PATCH 1/3] chore: adapt STM32Cube_FW sources
+Subject: [PATCH 1/4] chore: adapt STM32Cube_FW sources
 
 Signed-off-by: Frederic Pillon <frederic.pillon@st.com>
 ---

--- a/extras/STM32Cube_FW/0002-fix-include-a-timeout-when-waiting-for-the-cmd_resp.patch
+++ b/extras/STM32Cube_FW/0002-fix-include-a-timeout-when-waiting-for-the-cmd_resp.patch
@@ -1,7 +1,7 @@
-From 598c654f18fc9389be8326610a51052943151f04 Mon Sep 17 00:00:00 2001
+From 5d07a0e5c0463965f8cf8dde6076b5cf2c779e90 Mon Sep 17 00:00:00 2001
 From: Frederic Pillon <frederic.pillon@st.com>
 Date: Thu, 13 Jul 2023 17:16:40 +0200
-Subject: [PATCH 2/3] fix: include a timeout when waiting for the cmd_resp
+Subject: [PATCH 2/4] fix: include a timeout when waiting for the cmd_resp
 
 Signed-off-by: Frederic Pillon <frederic.pillon@st.com>
 ---

--- a/extras/STM32Cube_FW/0003-chore-add-support-for-customize-app_conf_default.h.patch
+++ b/extras/STM32Cube_FW/0003-chore-add-support-for-customize-app_conf_default.h.patch
@@ -1,7 +1,7 @@
-From 663ed22fd680de1f32c542df0799c403665ecb2e Mon Sep 17 00:00:00 2001
+From 370e1082edae9b69d50f824db85b5cbe3b786e79 Mon Sep 17 00:00:00 2001
 From: Frederic Pillon <frederic.pillon@st.com>
 Date: Mon, 12 Dec 2022 17:29:27 +0100
-Subject: [PATCH 3/3] chore: add support for customize app_conf_default.h
+Subject: [PATCH 3/4] chore: add support for customize app_conf_default.h
 
 Signed-off-by: Frederic Pillon <frederic.pillon@st.com>
 ---

--- a/extras/STM32Cube_FW/0004-fix-TL_Evt_t-payload-size-for-reset.patch
+++ b/extras/STM32Cube_FW/0004-fix-TL_Evt_t-payload-size-for-reset.patch
@@ -1,0 +1,30 @@
+From b294edcaee311c15dfb307ea1298ae88b16a92bf Mon Sep 17 00:00:00 2001
+From: Frederic Pillon <frederic.pillon@st.com>
+Date: Mon, 24 Jul 2023 10:55:20 +0200
+Subject: [PATCH 4/4] fix: TL_Evt_t payload size for reset
+
+Within STM32CubeWB v1.17.0 update TL_Evt_t payload size was reduced.
+This produce a warning -Warray-bounds due to the reset management
+which require 4 bytes.
+
+Signed-off-by: Frederic Pillon <frederic.pillon@st.com>
+---
+ src/utility/STM32Cube_FW/tl.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/utility/STM32Cube_FW/tl.h b/src/utility/STM32Cube_FW/tl.h
+index 8e8c6cb..7452087 100644
+--- a/src/utility/STM32Cube_FW/tl.h
++++ b/src/utility/STM32Cube_FW/tl.h
+@@ -108,7 +108,7 @@ typedef PACKED_STRUCT
+ {
+   uint8_t   evtcode;
+   uint8_t   plen;
+-  uint8_t   payload[2];
++  uint8_t   payload[4];
+ } TL_Evt_t;
+ 
+ typedef PACKED_STRUCT
+-- 
+2.38.0.windows.1
+

--- a/src/utility/STM32Cube_FW/tl.h
+++ b/src/utility/STM32Cube_FW/tl.h
@@ -108,7 +108,7 @@ typedef PACKED_STRUCT
 {
   uint8_t   evtcode;
   uint8_t   plen;
-  uint8_t   payload[2];
+  uint8_t   payload[4];
 } TL_Evt_t;
 
 typedef PACKED_STRUCT


### PR DESCRIPTION
Within last CubeWB update TL_Evt_t payload size was reduced. This produce a warning -Warray-bounds due to the reset management which require 4 bytes.
    